### PR TITLE
fix line delimiter for linux

### DIFF
--- a/src/org/openscience/jmol/app/InputScannerThread.java
+++ b/src/org/openscience/jmol/app/InputScannerThread.java
@@ -26,7 +26,7 @@ public class InputScannerThread extends Thread {
   @Override
   public synchronized void start() {
     scanner = new Scanner(System.in);
-    scanner.useDelimiter("\n");
+    scanner.useDelimiter(System.lineSeparator());
     super.start();
   }
 
@@ -77,7 +77,7 @@ public class InputScannerThread extends Thread {
   void scan() {
     while (scanner.hasNext()) {
       String s = scanner.next();
-      s = s.substring(0, s.length() - 1);
+      s = s.substring(0, s.length());
       if (s.toLowerCase().equals("exitjmol"))
         System.exit(0);
       if (vwr.checkHalt(s, false)) {


### PR DESCRIPTION
This fixes the problem of needing a space at the end of interactive jmol commands in linux.  It works in Windows, too.  I can't test on mac.  I'm not sure where else this scanner is used, so I'm not sure if changing the delimiter affects something in another part of the program.