### PR TITLE
Fix xss issue in php error output

### DIFF
--- a/php/jsmol.php
+++ b/php/jsmol.php
@@ -170,7 +170,7 @@ if ($call == "getInfoFromDatabase") {
 ob_start();
 
  if ($myerror != "") {
-   $output = $myerror;
+   $output = htmlspecialchars($myerror);
  } else { 
    if ($imagedata != "") {
   	$output = $imagedata;


### PR DESCRIPTION
This php change sanitises error message output to prevent Reflected Cross-Site Scripting using htmlspecialchars() e.g. php/jsmol.php?call=getInfoFromDatabase&database=<svg/onload=alert(document.cookie)> will output an error which executes the javascript.