### PR TITLE
enables reading of MO coefficients when G/H/I functions are present

### DIFF
--- a/src/org/jmol/adapter/readers/quantum/GaussianReader.java
+++ b/src/org/jmol/adapter/readers/quantum/GaussianReader.java
@@ -451,14 +451,24 @@ public class GaussianReader extends MOReader {
         .indexOf("5D") > 0));
     boolean doSphericalF = (calculationType != null && (calculationType
         .indexOf("7F") > 0));
+    // From the manual of Gaussian (https://gaussian.com/basissets/)
+    // Visited on 21-Oct-2023:
+    // "7F and 10F: Use 7 or 10 f functions (pure vs. Cartesian f functions), 
+    // respectively. These keywords also apply to all higher functions (g and 
+    // beyond)."
+    /*
     boolean doSphericalG = (calculationType != null && (calculationType
         .indexOf("9G") > 0));
     boolean doSphericalH = (calculationType != null && (calculationType
         .indexOf("11H") > 0));
     boolean doSphericalI = (calculationType != null && (calculationType
         .indexOf("13I") > 0));
-    boolean doSphericalHighL = (doSphericalG ||doSphericalH ||doSphericalI);
-    boolean doSpherical = (doSphericalD ||doSphericalF || doSphericalHighL);
+    */
+    boolean doSphericalG = doSphericalF;
+    boolean doSphericalH = doSphericalF;
+    boolean doSphericalI = doSphericalF;
+    boolean doSphericalHighL = (doSphericalG || doSphericalH ||doSphericalI);
+    boolean doSpherical = (doSphericalD || doSphericalF || doSphericalHighL);
     boolean isGeneral = (line.indexOf("general basis input") >= 0);
     if (isGeneral) {
       while (rd() != null && line.length() > 0) {
@@ -470,8 +480,11 @@ public class GaussianReader extends MOReader {
           slater[0] = ac;
           tokens = getTokens();
           String oType = tokens[0];
-          if (doSphericalF && oType.indexOf("F") >= 0 || doSphericalD
-              && oType.indexOf("D") >= 0)
+          if ((doSphericalF && oType.indexOf("F") >= 0)
+              || (doSphericalD && oType.indexOf("D") >= 0)
+              || (doSphericalG && oType.indexOf("G") >= 0)
+              || (doSphericalH && oType.indexOf("H") >= 0)
+              || (doSphericalI && oType.indexOf("I") >= 0))
             slater[1] = BasisFunctionReader.getQuantumShellTagIDSpherical(oType);
           else
             slater[1] = BasisFunctionReader.getQuantumShellTagID(oType);

--- a/src/org/jmol/quantum/QS.java
+++ b/src/org/jmol/quantum/QS.java
@@ -82,7 +82,7 @@ public class QS {
 //  I_CARTESIAN("I","XXXXXX",12,11);
 
   public static boolean isQuantumBasisSupported(char ch) {
-    return ("SPLDF".indexOf(Character.toUpperCase(ch)) >= 0);
+    return ("SPLDFGHI".indexOf(Character.toUpperCase(ch)) >= 0);
   }
   
 


### PR DESCRIPTION
Hi, 

I find that these changes are required to make Jmol process the MO of systems that include spherical G (and higher) functions in a Gaussian log/output file. Without such changes the coefficients are not properly read and MOs cannot be displayed. 

For example (in console):
`load somefile.out`
`mo 123`
returns
`mo 123  with cutoff=NaN`
and no MO is depicted.

While the changes would trigger the warning about unsupported basis set (https://github.com/BobHanson/Jmol-SwingJS/blob/7269d1e851d59b8b162462667c8b54549218ea77/src/org/jmol/quantum/MOCalculation.java#L365C6-L365C6, if logging levels are appropriate) I find that these functions that are part of quadruple-tzeta basis set I use have very small coefficients in the chemically relevant MOs. So, perhaps I would prefer to be able to see the MOs even if the very small perturbation due to these low contributions is not accounted for (I guess this is the effect of having "unsupported basis functions"?). 

Cheers!