### PR TITLE
16.2.1

### DIFF
--- a/Jmol.properties
+++ b/Jmol.properties
@@ -1,3 +1,3 @@
 Jmol.___JmolDate="$Date: 2023-01-10 13:20:33 -0600 (Tue, 10 Jan 2023) $"
 Jmol.___fullJmolProperties="src/org/jmol/viewer/Jmol.properties"
-Jmol.___JmolVersion="16.1.64" // (swingJS) also 16.1.63 (legacy)
+Jmol.___JmolVersion="16.2.2" // (swingJS) also 16.2.1 (legacy)

--- a/src/javajs/util/CU.java
+++ b/src/javajs/util/CU.java
@@ -34,6 +34,7 @@ public class CU {
   }
   
   private final static String[] colorNames = {
+    "contrast",             // fedcba
     "black",                // 000000
     "pewhite",              // ffffff
     "pecyan",               // 00ffff
@@ -203,6 +204,7 @@ public class CU {
   
   private final static int[] colorArgbs = {
   //#FFFFC3 hover
+    0xFFfedcba, // CONTRAST (colix = 3)
     0xFF000000, // black
     // plus the PE chain colors
     0xFFffffff, // pewhite

--- a/src/javajs/util/M34d.java
+++ b/src/javajs/util/M34d.java
@@ -346,7 +346,7 @@ public abstract class M34d implements JSONEncodable {
     m22 *= x;
   }
 
-  protected void transpose33() {
+  public void transpose33() {
     double tmp = m01;
     m01 = m10;
     m10 = tmp;

--- a/src/org/jmol/adapter/readers/cif/MMCifReader.java
+++ b/src/org/jmol/adapter/readers/cif/MMCifReader.java
@@ -618,7 +618,7 @@ public class MMCifReader extends CifReader {
         Logger.info((isNCS ? "noncrystallographic symmetry operator " : "assembly operator ") + id + " " + xyz);
         M4d m4 = new M4d();
         if (count != 12) {
-          symmetry.getMatrixFromString(xyz, m, false, 0);
+          symmetry.getMatrixFromString(xyz, m);
           m[3] *= symmetry.getUnitCellInfoType(SimpleUnitCell.INFO_A) / 12;
           m[7] *= symmetry.getUnitCellInfoType(SimpleUnitCell.INFO_B) / 12;
           m[11] *= symmetry.getUnitCellInfoType(SimpleUnitCell.INFO_C) / 12;

--- a/src/org/jmol/adapter/readers/cif/MSRdr.java
+++ b/src/org/jmol/adapter/readers/cif/MSRdr.java
@@ -8,7 +8,7 @@ import org.jmol.adapter.smarter.Atom;
 import org.jmol.adapter.smarter.AtomSetCollection;
 import org.jmol.adapter.smarter.AtomSetCollectionReader;
 import org.jmol.adapter.smarter.MSInterface;
-import org.jmol.api.SymmetryInterface;
+import org.jmol.adapter.smarter.XtalSymmetry.FileSymmetry;
 import org.jmol.util.BoxInfo;
 import org.jmol.util.Escape;
 import org.jmol.util.Logger;
@@ -224,7 +224,7 @@ public class MSRdr implements MSInterface {
 
   private boolean finalized;
 
-  private SymmetryInterface symmetry, supercellSymmetry;
+  private FileSymmetry symmetry, supercellSymmetry;
 
   private Lst<String> legendres;
 
@@ -329,7 +329,7 @@ public class MSRdr implements MSInterface {
    * 
    */
   @Override
-  public void setModulation(boolean isPost, SymmetryInterface symmetry) throws Exception {
+  public void setModulation(boolean isPost, FileSymmetry symmetry) throws Exception {
     if (modDim == 0 || htModulation == null)
       return;
     if (modDebug)
@@ -433,7 +433,7 @@ public class MSRdr implements MSInterface {
     //cr.symmetry = cr.asc.getSymmetry();
     if (symmetry != null)
       nOps = symmetry.getSpaceGroupOperationCount();
-    supercellSymmetry = cr.asc.getXSymmetry().symmetry;
+    supercellSymmetry = cr.asc.getXSymmetry().getSymmetry();
     if (supercellSymmetry  == symmetry)
       supercellSymmetry = null;
     iopLast = -1;
@@ -946,7 +946,7 @@ public class MSRdr implements MSInterface {
         for (Entry<String, Double> e : ms.htUij.entrySet())
           addUStr(a, e.getKey(), e.getValue().doubleValue());
 
-        SymmetryInterface sym = getAtomSymmetry(a, symmetry);
+        FileSymmetry sym = getAtomSymmetry(a, symmetry);
         t = cr.asc.getXSymmetry().addRotatedTensor(a,
             sym.getTensor(cr.vwr, a.anisoBorU), iop, false, sym);
         t.isModulated = true;
@@ -989,8 +989,8 @@ public class MSRdr implements MSInterface {
    * 
    */
   @Override
-  public SymmetryInterface getAtomSymmetry(Atom a,
-                                           SymmetryInterface defaultSymmetry) {
+  public FileSymmetry getAtomSymmetry(Atom a,
+                                           FileSymmetry defaultSymmetry) {
     Subsystem ss;
     return (htSubsystems == null || (ss = getSubsystem(a)) == null ? defaultSymmetry
         : ss.getSymmetry());
@@ -1010,7 +1010,7 @@ public class MSRdr implements MSInterface {
     return (ss == null ? modMatrices : ss.getModMatrices());
   }
 
-  private SymmetryInterface getSymmetry(Atom a) {
+  private FileSymmetry getSymmetry(Atom a) {
     Subsystem ss = getSubsystem(a);
     return (ss == null ? symmetry : ss.getSymmetry());
   }
@@ -1027,7 +1027,7 @@ public class MSRdr implements MSInterface {
       minXYZ0 = maxXYZ0 = null;
       return;
     }
-    SymmetryInterface symmetry = getDefaultUnitCell();
+    FileSymmetry symmetry = getDefaultUnitCell();
     minXYZ0 = P3d.newP(minXYZ);
     maxXYZ0 = P3d.newP(maxXYZ);
     P3d pt0 = P3d.newP(minXYZ);
@@ -1041,7 +1041,7 @@ public class MSRdr implements MSInterface {
       return;
     }
     for (Entry<String, Subsystem> e : htSubsystems.entrySet()) {
-      SymmetryInterface sym = e.getValue().getSymmetry();
+      FileSymmetry sym = e.getValue().getSymmetry();
       for (int i = 8; --i >= 0;) {
         pt.x = (pts[i].x == 0 ? pt0.x : pt1.x);
         pt.y = (pts[i].y == 0 ? pt0.y : pt1.y);
@@ -1051,7 +1051,7 @@ public class MSRdr implements MSInterface {
     }
   }
 
-  private void expandMinMax(P3d pt, SymmetryInterface sym, P3d minXYZ, P3d maxXYZ) {
+  private void expandMinMax(P3d pt, FileSymmetry sym, P3d minXYZ, P3d maxXYZ) {
     P3d pt2 = P3d.newP(pt);
     double slop = 0.0001;
     sym.toFractional(pt2, false);
@@ -1073,7 +1073,7 @@ public class MSRdr implements MSInterface {
     if (!cr.doApplySymmetry)
       return;
     AtomSetCollection asc = cr.asc;
-    SymmetryInterface sym = getDefaultUnitCell();
+    FileSymmetry sym = getDefaultUnitCell();
     Atom[] atoms = asc.atoms;
     P3d pt = new P3d();
     BS bs = asc.getBSAtoms(-1);
@@ -1108,13 +1108,13 @@ public class MSRdr implements MSInterface {
     }
   }
 
-  private SymmetryInterface getDefaultUnitCell() {
+  private FileSymmetry getDefaultUnitCell() {
     return (modCell != null && htSubsystems.containsKey(modCell) ? htSubsystems
         .get(modCell).getSymmetry() : cr.asc.getSymmetry());
   }
 
   @Override
-  public SymmetryInterface getSymmetryFromCode(String code) {
+  public FileSymmetry getSymmetryFromCode(String code) {
     return htSubsystems.get(code).getSymmetry();
   }
 

--- a/src/org/jmol/adapter/readers/cif/Subsystem.java
+++ b/src/org/jmol/adapter/readers/cif/Subsystem.java
@@ -2,7 +2,7 @@ package org.jmol.adapter.readers.cif;
 
 import java.util.Map.Entry;
 
-import org.jmol.api.SymmetryInterface;
+import org.jmol.adapter.smarter.XtalSymmetry.FileSymmetry;
 import org.jmol.util.Logger;
 import org.jmol.util.SimpleUnitCell;
 
@@ -10,8 +10,6 @@ import javajs.util.Lst;
 import javajs.util.M4d;
 import javajs.util.Matrix;
 import javajs.util.T3d;
-import javajs.util.T3d;
-import javajs.util.V3d;
 import javajs.util.V3d;
 
 
@@ -22,7 +20,7 @@ class Subsystem {
   private int d;
   private Matrix w;
 
-  private SymmetryInterface symmetry;
+  private FileSymmetry symmetry;
   private Matrix[] modMatrices;
   private boolean isFinalized;
 
@@ -33,7 +31,7 @@ class Subsystem {
     d = w.getArray().length - 3;
   }
 
-  public SymmetryInterface getSymmetry() {
+  public FileSymmetry getSymmetry() {
     if (!isFinalized)
       setSymmetry(true);
     return symmetry;
@@ -74,7 +72,7 @@ class Subsystem {
     
     // Part 2: Get the new unit cell and symmetry operators
 
-    SymmetryInterface s0 = msRdr.cr.asc.getSymmetry();
+    FileSymmetry s0 = msRdr.cr.asc.getSymmetry();
     T3d[] vu43 = s0.getUnitCellVectors();
     T3d[] vr43 = SimpleUnitCell.getReciprocal(vu43, null, 1);
 
@@ -104,7 +102,7 @@ class Subsystem {
     for (int i = 0; i < 3; i++)
       uc_nu[i + 1] = V3d.new3(a[i][0], a[i][1], a[i][2]);    
     uc_nu = SimpleUnitCell.getReciprocal(uc_nu, null, 1);
-    symmetry = ((SymmetryInterface) msRdr.cr.getInterface("org.jmol.symmetry.Symmetry")).getUnitCell(uc_nu, false, null);
+    (symmetry = msRdr.cr.asc.newFileSymmetry()).getUnitCell(uc_nu, false, null);
     modMatrices = new Matrix[] { sigma_nu, tFactor };
     if (!setOperators)
       return;

--- a/src/org/jmol/adapter/readers/cif/TopoCifParser.java
+++ b/src/org/jmol/adapter/readers/cif/TopoCifParser.java
@@ -7,7 +7,7 @@ import org.jmol.adapter.readers.cif.CifReader.Parser;
 import org.jmol.adapter.smarter.Atom;
 import org.jmol.adapter.smarter.Bond;
 import org.jmol.api.JmolAdapter;
-import org.jmol.api.SymmetryInterface;
+import org.jmol.symmetry.Symmetry;
 import org.jmol.symmetry.SymmetryOperation;
 import org.jmol.util.Edge;
 import org.jmol.util.JmolMolecule;
@@ -160,7 +160,7 @@ public class TopoCifParser implements Parser {
   private String allowedTypes;
 
   String netNotes = "";
-  private SymmetryInterface sym;
+  private Symmetry sym;
   String selectedNet;
 
   // CifParser supports up to 100 fields

--- a/src/org/jmol/adapter/readers/pdb/PdbReader.java
+++ b/src/org/jmol/adapter/readers/pdb/PdbReader.java
@@ -31,8 +31,9 @@ import org.jmol.adapter.smarter.Atom;
 import org.jmol.adapter.smarter.AtomSetCollection;
 import org.jmol.adapter.smarter.AtomSetCollectionReader;
 import org.jmol.adapter.smarter.Structure;
+import org.jmol.adapter.smarter.XtalSymmetry;
+import org.jmol.adapter.smarter.XtalSymmetry.FileSymmetry;
 import org.jmol.api.JmolAdapter;
-import org.jmol.api.SymmetryInterface;
 import org.jmol.c.STR;
 import org.jmol.util.Escape;
 import org.jmol.util.Logger;
@@ -421,7 +422,7 @@ public class PdbReader extends AtomSetCollectionReader {
     checkUnitCellParams();
     if (!isCourseGrained)
       connectAll(maxSerial, isConnectStateBug);
-    SymmetryInterface symmetry;
+    XtalSymmetry.FileSymmetry symmetry;
     if (vBiomolecules != null && vBiomolecules.size() > 0 && asc.ac > 0) {
       asc.setCurrentModelInfo("biomolecules", vBiomolecules);
       setBiomoleculeAtomCounts();
@@ -433,7 +434,7 @@ public class PdbReader extends AtomSetCollectionReader {
       }
     }
     if (vTlsModels != null) {
-      symmetry = (SymmetryInterface) getInterface("org.jmol.symmetry.Symmetry");
+      symmetry = asc.newFileSymmetry();
       int n = asc.atomSetCount;
       if (n == vTlsModels.size()) {
         for (int i = n; --i >= 0;)
@@ -489,7 +490,7 @@ public class PdbReader extends AtomSetCollectionReader {
     }
   }
 
-  private void checkForResidualBFactors(SymmetryInterface symmetry) {
+  private void checkForResidualBFactors(XtalSymmetry.FileSymmetry symmetry) {
     Atom[] atoms = asc.atoms;
     boolean isResidual = false;
      for (int i = asc.ac; --i >= 0;) {
@@ -1849,7 +1850,7 @@ public class PdbReader extends AtomSetCollectionReader {
    * @param symmetry 
    */
   @SuppressWarnings("unchecked")
-  private void setTlsGroups(int iGroup, int iModel, SymmetryInterface symmetry) {
+  private void setTlsGroups(int iGroup, int iModel, XtalSymmetry.FileSymmetry symmetry) {
 
     // TLS.groupCount   Integer
     // TLS.groups       List of Map
@@ -1946,7 +1947,7 @@ public class PdbReader extends AtomSetCollectionReader {
   private static final double _8PI2_ = (8 * Math.PI * Math.PI);
   private Map<Atom, double[]>tlsU;
   
-  private void setTlsTensor(Atom atom, Map<String, Object> group, SymmetryInterface symmetry) {
+  private void setTlsTensor(Atom atom, Map<String, Object> group, XtalSymmetry.FileSymmetry symmetry) {
     P3d origin = (P3d) group.get("origin");
     if (Double.isNaN(origin.x))
       return;

--- a/src/org/jmol/adapter/readers/quantum/GenNBOReader.java
+++ b/src/org/jmol/adapter/readers/quantum/GenNBOReader.java
@@ -940,7 +940,7 @@ public class GenNBOReader extends MOReader {
       return;
     line = null;
     int pt = 0;
-    for (int i = nOrbitals0, n = nOrbitals0 + nOrbitals; i < n; i++, pt++) {
+    for (int i = nOrbitals0, n = nOrbitals0 + nNOs; i < n; i++, pt++) {
       if (pt == nNOs) {
         if (isNBO) {
           readNBO37Occupancies(pt);

--- a/src/org/jmol/adapter/readers/xtal/GulpReader.java
+++ b/src/org/jmol/adapter/readers/xtal/GulpReader.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import org.jmol.adapter.smarter.Atom;
 import org.jmol.adapter.smarter.AtomSetCollectionReader;
-import org.jmol.api.SymmetryInterface;
+import org.jmol.symmetry.Symmetry;
 
 import javajs.util.PT;
 import javajs.util.V3d;
@@ -304,7 +304,7 @@ public class GulpReader extends AtomSetCollectionReader {
   public void applySymmetryAndSetTrajectory() throws Exception {
     if (coordinatesArePrimitive && iHaveUnitCell && doCheckUnitCell && primitiveData != null && !isPrimitive) {
       setModelParameters(false);
-      SymmetryInterface symFull = symmetry;
+      Symmetry symFull = symmetry;
       setModelParameters(true);
       // Full cell -- must convert primitive to conventional
       

--- a/src/org/jmol/adapter/readers/xtal/JanaReader.java
+++ b/src/org/jmol/adapter/readers/xtal/JanaReader.java
@@ -30,8 +30,8 @@ import java.util.Map.Entry;
 import org.jmol.adapter.smarter.Atom;
 import org.jmol.adapter.smarter.AtomSetCollectionReader;
 import org.jmol.adapter.smarter.MSInterface;
+import org.jmol.adapter.smarter.XtalSymmetry.FileSymmetry;
 import org.jmol.api.Interface;
-import org.jmol.api.SymmetryInterface;
 import org.jmol.util.Logger;
 import org.jmol.util.Modulation;
 
@@ -936,7 +936,7 @@ public class JanaReader extends AtomSetCollectionReader {
   private void adjustM40Occupancies() {
     Map<String, Integer> htSiteMult = new Hashtable<String, Integer>();    
     Atom[] atoms = asc.atoms;
-    SymmetryInterface symmetry = asc.getSymmetry();
+    FileSymmetry symmetry = asc.getSymmetry();
     for (int i = asc.ac; --i >= 0;) {
       Atom a = atoms[i];
       Integer ii = htSiteMult.get(a.atomName);

--- a/src/org/jmol/adapter/readers/xtal/SiestaReader.java
+++ b/src/org/jmol/adapter/readers/xtal/SiestaReader.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import org.jmol.adapter.smarter.Atom;
 
 /**
+ * 
+ * BH note: this reader was never set up to read Z-matrix structures such as benzenev4.1.fdf
+ * 
  * SIESTA http://www.icmab.es/siesta/
  * 
  * @author Pieremanuele Canepa, Room 104, FM Group School of Physical Sciences,
@@ -40,7 +43,8 @@ public class SiestaReader extends AtomSetCollectionReader {
   
   @Override
   protected boolean checkLine() throws Exception {
-    if (line.length() == 0 || line.charAt(0) == '#' || line.indexOf(' ') < 0)
+    if (line.length() == 0 || line.charAt(0) == '#' 
+        || line.indexOf(' ') < 0 && line.indexOf('\t') < 0 )
       return true;
     switch (state) {
     case STATE_UNKNOWN:

--- a/src/org/jmol/adapter/smarter/AtomSetCollection.java
+++ b/src/org/jmol/adapter/smarter/AtomSetCollection.java
@@ -29,9 +29,9 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
 
+import org.jmol.adapter.smarter.XtalSymmetry.FileSymmetry;
 import org.jmol.api.Interface;
 import org.jmol.api.JmolAdapter;
-import org.jmol.api.SymmetryInterface;
 import org.jmol.util.BSUtil;
 import org.jmol.util.Logger;
 import org.jmol.viewer.JC;
@@ -715,11 +715,14 @@ public class AtomSetCollection {
     return xtalSymmetry;
   }
 
-  public SymmetryInterface getSymmetry() {
+  public FileSymmetry newFileSymmetry() {
+    return getXSymmetry().newFileSymmetry();
+  }
+  public FileSymmetry getSymmetry() {
     return getXSymmetry().getSymmetry();
   }
 
-  public SymmetryInterface setSymmetry(SymmetryInterface symmetry) {
+  public FileSymmetry setSymmetry(FileSymmetry symmetry) {
     return (symmetry == null ? null : getXSymmetry().setSymmetry(symmetry));
   }
 
@@ -1255,5 +1258,6 @@ public class AtomSetCollection {
       }
     }
   }
+
 
 }

--- a/src/org/jmol/adapter/smarter/MSInterface.java
+++ b/src/org/jmol/adapter/smarter/MSInterface.java
@@ -2,7 +2,7 @@ package org.jmol.adapter.smarter;
 
 import java.util.Map;
 
-import org.jmol.api.SymmetryInterface;
+import org.jmol.adapter.smarter.XtalSymmetry.FileSymmetry;
 
 import javajs.util.Lst;
 import javajs.util.Matrix;
@@ -27,13 +27,13 @@ public interface MSInterface {
 
   int initialize(AtomSetCollectionReader r, int modDim) throws Exception;
 
-  void setModulation(boolean isPost, SymmetryInterface symmetry) throws Exception;
+  void setModulation(boolean isPost, XtalSymmetry.FileSymmetry symmetry) throws Exception;
 
-  SymmetryInterface getAtomSymmetry(Atom a, SymmetryInterface symmetry);
+  XtalSymmetry.FileSymmetry getAtomSymmetry(Atom a, XtalSymmetry.FileSymmetry symmetry);
 
   void setMinMax0(P3d minXYZ0, P3d maxXYZ0);
 
-  SymmetryInterface getSymmetryFromCode(String spaceGroupOperationCode);
+  XtalSymmetry.FileSymmetry getSymmetryFromCode(String spaceGroupOperationCode);
 
   boolean addLatticeVector(Lst<double[]> lattvecs, String substring) throws Exception;
 

--- a/src/org/jmol/api/SymmetryInterface.java
+++ b/src/org/jmol/api/SymmetryInterface.java
@@ -4,7 +4,6 @@ import java.util.Map;
 
 import org.jmol.modelset.Atom;
 import org.jmol.modelset.ModelSet;
-import org.jmol.util.Tensor;
 import org.jmol.viewer.Viewer;
 
 import javajs.util.BS;
@@ -22,8 +21,6 @@ public interface SymmetryInterface {
 
   int addSpaceGroupOperation(String xyz, int opId);
 
-  String addSubSystemOp(String code, Matrix rs, Matrix vs, Matrix sigma);
-
   void calculateCIPChiralityForAtoms(Viewer vwr, BS bsAtoms);
 
   String[] calculateCIPChiralityForSmiles(Viewer vwr, String smiles)
@@ -31,20 +28,9 @@ public interface SymmetryInterface {
 
   int addBioMoleculeOperation(M4d mat, boolean isReverse);
 
-  boolean addLatticeVectors(Lst<double[]> lattvecs);
-
-  boolean checkDistance(P3d f1, P3d f2, double distance, 
-                                        double dx, int iRange, int jRange, int kRange, P3d ptOffset);
-
-  boolean createSpaceGroup(int desiredSpaceGroupIndex,
-                                           String name,
-                                           Object data, int modDim);
-
   Object findSpaceGroup(Viewer vwr, BS atoms, String xyzList, double[] unitCellParams, T3d origin, boolean asString, boolean isAssign, boolean checkSupercell);
 
   int[] getCellRange();
-
-  T3d[] getConventionalUnitCell(String latticeType, M3d primitiveToCryst);
 
   boolean getCoordinatesAreFractional();
 
@@ -59,8 +45,6 @@ public interface SymmetryInterface {
   int getLatticeOp();
 
   char getLatticeType();
-
-  String getMatrixFromString(String xyz, double[] temp, boolean allowScaling, int modDim);
 
   Lst<String> getMoreInfo();
 
@@ -90,8 +74,6 @@ public interface SymmetryInterface {
 
   M4d getSpaceGroupOperation(int i);
   
-  String getSpaceGroupOperationCode(int op);
-
   int getSpaceGroupOperationCount();
   
   String getSpaceGroupXyz(int i, boolean doNormalize);
@@ -103,8 +85,6 @@ public interface SymmetryInterface {
   String getSymmetryInfoStr();
 
   M4d[] getSymmetryOperations();
-
-  Tensor getTensor(Viewer vwr, double[] anisoBorU);
 
   M4d getTransform(P3d fracA, P3d fracB, boolean debug);
 
@@ -178,10 +158,6 @@ public interface SymmetryInterface {
    */
   void setSpaceGroupTo(Object spaceGroup);
 
-  SymmetryInterface setSymmetryInfo(int modelIndex, Map<String, Object> modelAuxiliaryInfo, double[] notionalCell);
-
-  void setTimeReversal(int op, int val);
-
   SymmetryInterface setUnitCellFromParams(double[] params, boolean setRelative, double slop);
 
   void setUnitCell(SymmetryInterface uc);
@@ -190,14 +166,10 @@ public interface SymmetryInterface {
 
   void toFractional(T3d pt, boolean ignoreOffset);
   
-  void toFractionalM(M4d m);
-
-  boolean toFromPrimitive(boolean toPrimitive, char type, T3d[] oabc,
+   boolean toFromPrimitive(boolean toPrimitive, char type, T3d[] oabc,
                           M3d primitiveToCrystal);
 
   void toUnitCell(T3d pt, T3d offset);
-
-  void toUnitCellRnd(T3d pt, T3d offset);
 
   boolean unitCellEquals(SymmetryInterface uc2);
 
@@ -205,10 +177,6 @@ public interface SymmetryInterface {
 
   void initializeOrientation(M3d matUnitCellOrientation);
 
-  String fcoord(T3d p);
-
-  // floats
-  
   /**
    * 
    * @param ms
@@ -281,10 +249,9 @@ public interface SymmetryInterface {
 
   double getPrecision();
 
-  void setPrecision(double prec);
-
   boolean fixUnitCell(double[] unitCellParams);
 
-  void twelfthify(P3d pt);
+  String getSpaceGroupTitle();
 
+  boolean isSymmetryCell(SymmetryInterface sym);
 }

--- a/src/org/jmol/g3d/Graphics3D.java
+++ b/src/org/jmol/g3d/Graphics3D.java
@@ -370,6 +370,7 @@ final public class Graphics3D extends GData implements JmolRendererInterface {
     haveTranslucentObjects = wasScreened = false;
     pixel = pixel0;
     pixel.bgcolor = bgcolor;
+    contrastColix = C.getBgContrast(bgcolor);
     translucentCoverOnly = !translucentMode;
     if (pbuf == null) {
       platform.allocateBuffers(windowWidth, windowHeight, antialiasThisFrame,
@@ -748,7 +749,7 @@ final public class Graphics3D extends GData implements JmolRendererInterface {
     }
     shadesCurrent = getShades(colix);
     currentShadeIndex = -1;
-    setColor(getColorArgbOrGray(colix));
+    setColor(colix == C.COLIX_CONTRAST ? contrastColix : getColorArgbOrGray(colix));
     return true;
   }
 

--- a/src/org/jmol/minimize/Minimizer.java
+++ b/src/org/jmol/minimize/Minimizer.java
@@ -41,6 +41,7 @@ import org.jmol.util.BSUtil;
 import org.jmol.util.Edge;
 import org.jmol.util.Escape;
 import org.jmol.util.Logger;
+import org.jmol.viewer.JC;
 import org.jmol.viewer.JmolAsyncException;
 import org.jmol.viewer.Viewer;
 
@@ -144,7 +145,7 @@ public class Minimizer {
     isSilent = ((flags & Viewer.MIN_SILENT) == Viewer.MIN_SILENT);
     isQuick = (ff.indexOf("2D") >= 0
         || (flags & Viewer.MIN_QUICK) == Viewer.MIN_QUICK);
-    modelkitMinimizing = (bsBasis != null && vwr.getModelkitPropertySafely("minimizing") == Boolean.TRUE);
+    modelkitMinimizing = (bsBasis != null && vwr.getModelkitPropertySafely(JC.MODELKIT_MINIMIZING) == Boolean.TRUE);
     if (bsBasis != null) {
       if (bsFixed == null)
         bsFixed = new BS();

--- a/src/org/jmol/modelkit/ModelKitPopupResourceBundle.java
+++ b/src/org/jmol/modelkit/ModelKitPopupResourceBundle.java
@@ -52,7 +52,7 @@ public class ModelKitPopupResourceBundle extends PopupResource {
   
   private static String[][] menuContents = {
     { MENU_NAME, "atomMenu bondMenu xtalMenu optionsMenu" },
-    { "optionsMenu", "new center addh minimize hmin " +
+    { "optionsMenu", "new ekey center addh minimize hmin " +
         " - undo redo - SIGNEDsaveFile SIGNEDsaveState exit!Persist" },
     { ModelKit.ATOM_MODE , "assignAtom_XxP!RD dragAtomP!RD dragMinimizeP!RD dragMoleculeP!RD dragMinimizeMoleculeP!RD " +
         "invertStereoP!RD -  assignAtom_XP!RD assignAtom_CP!RD assignAtom_HP!RD assignAtom_NP!RD assignAtom_OP!RD assignAtom_FP!RD assignAtom_ClP!RD assignAtom_BrP!RD " +
@@ -60,10 +60,21 @@ public class ModelKitPopupResourceBundle extends PopupResource {
         "moreAtomMenu assignAtom_plP!RD assignAtom_miP!RD" },
     { "moreAtomMenu", "clearQPersist , _??P!RD _??P!RD _??P!RD _??P!RD _??P!RD _??P!RD " },
     { ModelKit.BOND_MODE, "assignBond_0P!RD assignBond_1P!RD assignBond_2P!RD assignBond_3P!RD assignBond_pP!RD assignBond_mP!RD rotateBondP!RD" },
-    { ModelKit.XTAL_MODE, "xtalModePersistMenu xtalSelPersistMenu xtalSelOpPersistMenu operator xtalPackingPersistMenu xtalEditOptPersistMenu xtalOptionsPersistMenu" },
+    { ModelKit.XTAL_MODE, ""
+        //+ "xtalModePersistMenu "
+        //+ "xtalSelPersistMenu "
+        + "xtalSelOpPersistMenu "
+        + "operator "
+        //+ "xtalPackingPersistMenu "
+        //+ "xtalEditOptPersistMenu "
+        //+ "xtalOptionsPersistMenu" 
+        },
     { "xtalModePersistMenu", "mkmode_molecular mkmode_view mkmode_edit" }, 
     { "xtalSelPersistMenu", "mksel_atom mksel_position" },    
-    { "xtalSelOpPersistMenu", "xtalOp!PersistMenu mkselop_atom2 mkselop_addOffset" },
+    { "xtalSelOpPersistMenu", "xtalOp!PersistMenu "
+        //+ "mkselop_atom2 "
+        //+ "mkselop_addOffset" 
+        },
     { "xtalEditOptPersistMenu", "mksymmetry_none mksymmetry_retainLocal mksymmetry_applyLocal mksymmetry_applyFull" },
 
     { "xtalPackingPersistMenu", "mkunitcell_packed mkunitcell_extend" },
@@ -73,6 +84,7 @@ public class ModelKitPopupResourceBundle extends PopupResource {
   
   private static String[][] structureContents = {
       { "new" , "zap" },
+      { "ekey" , "set elementkey= @{!elementkey}" },
     { "center" , "zoomto 0 {visible} 0/1.5" },
     { "addh" , "calculate hydrogens {model=_lastframe}" },
     { "minimize" , "minimize" },
@@ -119,14 +131,15 @@ public class ModelKitPopupResourceBundle extends PopupResource {
         "mksymmetry_retainLocal", GT.$("retain local"),
         "mksymmetry_applyLocal", GT.$("apply local"),
         "mksymmetry_applyFull", GT.$("apply full"),
-        "mkunitcell_extend", GT.$("extend cell"),
-        "mkunitcell_packed", GT.$("pack cell"),
+        "mkunitcell_extend", GT.$("this operator"),
+        "mkunitcell_packed", GT.$("add translation"),
         "mkasymmetricUnit", GT.$("asymmetric unit"),
         "mkallAtoms", GT.$("all atoms"),
         "new", GT.$("new"),
         "undo", GT.$("undo (CTRL-Z)"),
         "redo", GT.$("redo (CTRL-Y)"),
         "center", GT.$("center"),
+        "ekey", GT.$("element key"),
         "addh", GT.$("add hydrogens"),
         "minimize", GT.$("minimize"),
         "hmin", GT.$("fix hydrogens and minimize"),

--- a/src/org/jmol/modelset/AtomCollection.java
+++ b/src/org/jmol/modelset/AtomCollection.java
@@ -2940,9 +2940,9 @@ abstract public class AtomCollection {
     SymmetryInterface sym = (atomIndex < 0 || atomIndex >= ac ? vwr.getOperativeSymmetry()
         : at[atomIndex].getUnitCell());
     boolean isRandom = (pt != null && Double.isNaN(pt.x));
-    return (sym == null ? new Lst<P3d>() : sym
+    Lst<P3d> ret = (sym == null ? null : sym
         .generateCrystalClass(isRandom ? null : pt != null ? pt : at[atomIndex]));
-
+    return (ret == null ? new Lst<P3d>() : ret);
   }
 
   public static boolean isDeleted(Atom atom) {

--- a/src/org/jmol/modelset/Model.java
+++ b/src/org/jmol/modelset/Model.java
@@ -151,8 +151,7 @@ public class Model {
 
   public String pdbID;
 
-  public Model() {
-    
+  public Model() { 
   }
   
   public Model set(ModelSet modelSet, int modelIndex, int trajectoryBaseIndex,
@@ -327,8 +326,7 @@ public class Model {
   }
 
   public void setSimpleCage(SymmetryInterface ucell) {
-    simpleCage = ucell;
-    if (ucell != null) {
+    if ((simpleCage = ucell) != null) {
       auxiliaryInfo.put("unitCellParams", ucell.getUnitCellParams());
     }
   }

--- a/src/org/jmol/modelset/ModelLoader.java
+++ b/src/org/jmol/modelset/ModelLoader.java
@@ -43,6 +43,7 @@ import org.jmol.c.VDW;
 import org.jmol.modelsetbio.BioModel;
 import org.jmol.modelsetbio.BioResolver;
 import org.jmol.script.T;
+import org.jmol.symmetry.Symmetry;
 import org.jmol.util.BSUtil;
 import org.jmol.util.Edge;
 import org.jmol.util.Elements;
@@ -820,6 +821,7 @@ public final class ModelLoader {
         mbs.set(ms.ac + nAtoms);
         mbs.clearAll();
         model.isOrderly = (appendToModelIndex == null);
+        System.out.println("ML " + appendToModelIndex + " " + model.isOrderly);
         isPdbThisModel = model.isBioModel;
         iLast = modelIndex;
         addH = isPdbThisModel && doAddPDBHydrogens;
@@ -871,7 +873,7 @@ public final class ModelLoader {
         iLast = atoms[i].mi;
         Model m = models[iLast];
         m.firstAtomIndex = i;
-        m.isOrderly = (m.act == m.bsAtoms.length()); 
+        m.isOrderly = (m.act == m.bsAtoms.length() - i); 
         VDW vdwtype = ms.getDefaultVdwType(iLast);
         if (vdwtype != vdwtypeLast) {
           Logger.info("Default Van der Waals type for model" + " set to "
@@ -1133,7 +1135,7 @@ public final class ModelLoader {
       for (int i = 0, pt = 0; i < ms.mc; i++) {
         if (haveMergeCells && i < baseModelCount) {
           ms.unitCells[i] = modelSet0.unitCells[i];
-        } else {
+        } else if (ms.getModelAuxiliaryInfo(i).get("spaceGroupIndex") != null) {
           ms.unitCells[i] = Interface.getSymmetry(vwr, "file");
           double[] notionalCell = null;
           if (isTrajectory) {
@@ -1142,7 +1144,8 @@ public final class ModelLoader {
             if (lst != null)
               notionalCell = lst.get(pt++);
           }
-          ms.unitCells[i].setSymmetryInfo(i, ms.getModelAuxiliaryInfo(i), notionalCell);
+          
+          ((Symmetry) ms.unitCells[i]).setSymmetryInfoFromFile(ms, i, notionalCell);
         }
       }
     }

--- a/src/org/jmol/modelset/Text.java
+++ b/src/org/jmol/modelset/Text.java
@@ -555,8 +555,6 @@ public class Text {
   public final static int PYMOL_LABEL_OFFSET_ABS_PIX = PYMOL_LABEL_OFFSET_PIX;
   public final static int PYMOL_LABEL_OFFSET_REL_PIX = PYMOL_LABEL_OFFSET_REL | PYMOL_LABEL_OFFSET_PIX;
 
-  public static final int COLOR_CONTRAST = 0xFF123456;
-  
   public double[] pymolOffset;
 
   protected int windowWidth;

--- a/src/org/jmol/render/AxesRenderer.java
+++ b/src/org/jmol/render/AxesRenderer.java
@@ -70,8 +70,8 @@ public class AxesRenderer extends CageRenderer {
         && !ms.getJmolFrameType(modelIndex).equals("plot data"))
       return false;
     boolean isUnitCell = (vwr.g.axesMode == T.axesunitcell);
-    SymmetryInterface unitcell = null;
-    if (isUnitCell && (unitcell = vwr.getCurrentUnitCell()) == null && modelIndex < 0)
+    SymmetryInterface unitcell = (isUnitCell ? vwr.getCurrentUnitCell() : null);
+    if (isUnitCell && (unitcell == null || modelIndex < 0))
       return false;
     imageFontScaling = vwr.imageFontScaling;
     if (vwr.areAxesTainted())

--- a/src/org/jmol/render/LabelsRenderer.java
+++ b/src/org/jmol/render/LabelsRenderer.java
@@ -29,6 +29,7 @@ import org.jmol.modelset.Group;
 import org.jmol.modelset.Text;
 import org.jmol.script.T;
 import org.jmol.shape.Labels;
+import org.jmol.util.C;
 import org.jmol.util.Font;
 import org.jmol.util.Point3fi;
 import org.jmol.viewer.JC;
@@ -107,7 +108,8 @@ public class LabelsRenderer extends FontLineShapeRenderer {
         continue;
       labelColix = labels.getColix2(i, atom, false);
       bgcolix = labels.getColix2(i, atom, true);
-      if (bgcolix == 0
+      // black on black or white on white or colorX on colorX will set the label to contrast
+      if (bgcolix == C.INHERIT_ALL // 0x0000
           && vwr.gdata.getColorArgbOrGray(labelColix) == backgroundColor)
         labelColix = backgroundColixContrast;
       fid = ((fids == null || i >= fids.length || fids[i] == 0) ? labels.zeroFontId

--- a/src/org/jmol/render/TextRenderer.java
+++ b/src/org/jmol/render/TextRenderer.java
@@ -51,7 +51,7 @@ class TextRenderer {
     boolean doPointer = ((mode & JC.LABEL_POINTER_ON) != 0);
     boolean isAntialiased = ((mode & MODE_IS_ANTIALIASED) != 0);
     short colix = text.colix;
-    if (text.isEcho && C.getArgb(colix) == Text.COLOR_CONTRAST)
+    if (text.isEcho && C.getArgb(colix) == JC.COLOR_CONTRAST)
       colix = vwr.cm.colixBackgroundContrast;
     boolean showText = g3d.setC(colix);
     if (!showText && (text.image == null

--- a/src/org/jmol/render/UccageRenderer.java
+++ b/src/org/jmol/render/UccageRenderer.java
@@ -182,7 +182,7 @@ public class UccageRenderer extends CageRenderer {
 
     if (!unitcell.isSimple()) {
       String sgName = (isPolymer ? "polymer"
-          : isSlab ? "slab" : unitcell.getSpaceGroupName());
+          : isSlab ? "slab" : unitcell.getSpaceGroupTitle());
       if (sgName != null) {
         if (sgName.startsWith("cell=!"))
           sgName = "cell=inverse[" + sgName.substring(6) + "]";
@@ -192,7 +192,7 @@ public class UccageRenderer extends CageRenderer {
           if (!isSlab && !isPolymer && intTab != null)
             sgName += " #" + intTab;
         }
-        if (!sgName.equals("-- [--]")) {
+        if (sgName.indexOf("-- [--]") < 0) {
           drawInfo(sgName, 0, null);
         }
       }

--- a/src/org/jmol/script/SV.java
+++ b/src/org/jmol/script/SV.java
@@ -131,6 +131,16 @@ public class SV extends T implements JSONEncodable {
     return this;
   }
 
+  /**
+   * Make a copy if this is a variable -- if it has myName != null.
+   * 
+   * @param v
+   * @return v or a copy of it
+   */
+  public static SV copySafely(SV v) {
+    return (v.myName == null ? v : new SV().setv(v));
+  }
+
   @SuppressWarnings("unchecked")
   static int sizeOf(T x) {
     switch (x == null ? nada : x.tok) {
@@ -954,7 +964,7 @@ public class SV extends T implements JSONEncodable {
       break;
     default:
       return ((tokenIn instanceof SV) && ((SV) tokenIn).myName != null 
-      ? newI(0).setv((SV) tokenIn) 
+      ? copySafely((SV) tokenIn) 
           : tokenIn);
     }
 
@@ -1631,7 +1641,7 @@ public class SV extends T implements JSONEncodable {
               : x.removeItemAt(x.size() - 1));
         }
         // array.push(value)
-        x.addLast(newI(0).setv(value));
+        x.addLast(copySafely(value));
       } else {
         if (value == null) {
           // assocArray.pop()
@@ -1665,7 +1675,7 @@ public class SV extends T implements JSONEncodable {
       }
       if (m != null) {
         //assocArray.push(key,value)
-        m.put(mapKey.asString(), newI(0).setv(value));
+        m.put(mapKey.asString(), copySafely(value));
       }
     }
     return this;
@@ -1856,7 +1866,12 @@ public class SV extends T implements JSONEncodable {
   }
 
   public void mapPut(String key, SV v) {
-    getMap().put(key, v);
+    switch (tok) {
+    case hash:
+    case context:
+      getMap().put(key, copySafely(v));
+      break;
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/src/org/jmol/script/ScriptCompiler.java
+++ b/src/org/jmol/script/ScriptCompiler.java
@@ -273,7 +273,6 @@ public class ScriptCompiler extends ScriptTokenParser {
   private boolean haveENDIF;
   
   private boolean compile0(boolean isFull) {
-    haveENDIF = false;
     script = cleanScriptComments(script);
     ichToken = script.indexOf(JC.STATE_VERSION_STAMP);
     isStateScript = (ichToken >= 0 && ichToken < 10); // leaves a bit of room for Proteopedia's "exit;\n" hack
@@ -284,6 +283,8 @@ public class ScriptCompiler extends ScriptTokenParser {
             script
                 .substring(ichToken + JC.STATE_VERSION_STAMP.length(), ptSemi)
                 .trim());
+    } else {
+        haveENDIF = (script.indexOf("endif") >= 0);
     }
     cchScript = script.length();
 

--- a/src/org/jmol/script/ScriptEval.java
+++ b/src/org/jmol/script/ScriptEval.java
@@ -5253,10 +5253,13 @@ public class ScriptEval extends ScriptExpr {
                             boolean isConcat, boolean doOrient, int nFiles,
                             int ac0, int modelCount0, boolean isData)
       throws ScriptException {
+    BS bs = BSUtil.newBitSet2(isAppend ? ac0 : 0, vwr.ms.ac);
     if (isAppend && (appendNew || nFiles > 1)) {
       vwr.setAnimationRange(-1, -1);
       vwr.setCurrentModelIndex(modelCount0);
     }
+    vwr.setModelkitPropertySafely(JC.MODELKIT_UPDATE_ATOM_KEYS, bs);
+
     String msg;
     if (scriptLevel == 0 && !isAppend && (isConcat || nFiles < 2)
         && (msg = (String) vwr.ms.getInfoM("modelLoadNote")) != null) {
@@ -5264,7 +5267,6 @@ public class ScriptEval extends ScriptExpr {
     }
     Object centroid = vwr.ms.getInfoM("centroidMinMax");
     if (AU.isAI(centroid) && vwr.ms.ac > 0) {
-      BS bs = BSUtil.newBitSet2(isAppend ? ac0 : 0, vwr.ms.ac);
       vwr.ms.setCentroid(bs, (int[]) centroid);
     }
     String script = vwr.g.defaultLoadScript;

--- a/src/org/jmol/script/ScriptExpr.java
+++ b/src/org/jmol/script/ScriptExpr.java
@@ -1247,7 +1247,7 @@ abstract class ScriptExpr extends ScriptParam {
           false, null, null, false);
       if (v.size() == 0)
         invArg();
-      ht.put(key, v.get(0));
+      ht.put(key, SV.copySafely(v.get(0)));
       i = iToken;
       if (tokAt(i) != T.comma)
         break;
@@ -2221,7 +2221,7 @@ abstract class ScriptExpr extends ScriptParam {
       invArg();
     if (chk || v.get(0).tok == T.nada)
       return null;
-    SV tv = SV.selectItemVar(SV.newS("").setv(v.get(nv - 1)));
+    SV tv = SV.selectItemVar(SV.copySafely(v.get(nv - 1)));
     if (nv > 1) {
       SV sel = (nv > 2 ? v.get(1) : null);
       t = v.get(0);

--- a/src/org/jmol/script/ScriptManager.java
+++ b/src/org/jmol/script/ScriptManager.java
@@ -317,6 +317,11 @@ public class ScriptManager implements JmolScriptManager {
 
   @Override
   public String evalFile(String strFilename) {
+    return evalFileArgs(strFilename, null);
+  }
+  
+  @Override
+  public String evalFileArgs(String strFilename, String args) {
     // app -s flag
     int ptWait = strFilename.indexOf(" -noqueue"); // for TestScripts.java
     if (ptWait >= 0) {
@@ -324,11 +329,6 @@ public class ScriptManager implements JmolScriptManager {
           "script " + PT.esc(strFilename.substring(0, ptWait)), "", false,
           false);
     }
-    return evalFileArgs(strFilename, null);
-  }
-  
-  @Override
-  public String evalFileArgs(String strFilename, String args) {
     // app -s flag and app -A flag
     return addScript("script " + PT.esc(strFilename) + (args == null ? "" : "(" + args + ")"), null, false);
     
@@ -778,7 +778,7 @@ public class ScriptManager implements JmolScriptManager {
   public BS addHydrogensInline(BS bsAtoms, Lst<Atom> vConnections, P3d[] pts,
                                Map<String, Object> htParams)
       throws Exception {
-    int iatom = bsAtoms.nextSetBit(0);
+    int iatom = (bsAtoms == null ? -1 : bsAtoms.nextSetBit(0));
     if (htParams == null)
       htParams = new Hashtable<String, Object>();
     int modelIndex = (iatom < 0 ? vwr.am.cmi : vwr.ms.at[iatom].mi);
@@ -786,16 +786,9 @@ public class ScriptManager implements JmolScriptManager {
       modelIndex = vwr.ms.mc - 1;
     htParams.put("appendToModelIndex", Integer.valueOf(modelIndex));
     boolean siteFixed = (htParams.containsKey("fixedSite"));
-    //    if (!vwr.ms.isAtomInLastModel(iatom))
-    //      return new BS();
-
-    // must be added to the LAST data set only
-
     BS bsA = vwr.getModelUndeletedAtomsBitSet(modelIndex);
     boolean wasAppendNew = vwr.g.appendNew;
     vwr.g.appendNew = false;
-    // BitSet bsB = getAtomBits(Token.hydrogen, null);
-    // bsA.andNot(bsB);
     int atomno = 0;
     for (int i = bsA.nextSetBit(0); i >= 0; i = bsA.nextSetBit(i + 1)) {
       int an = vwr.ms.at[i].getAtomNumber();

--- a/src/org/jmol/script/T.java
+++ b/src/org/jmol/script/T.java
@@ -1024,17 +1024,18 @@ public class T {
   public final static int drawpicking                    = booleanparam | 58;
   public final static int dsspcalchydrogen               = booleanparam | 59;
   public final static int dynamicmeasurements            = booleanparam | 60; //DEPRECATED; not implemented; leave here to avoid SET error
-  public final static int ellipsoidarcs                  = booleanparam | 61;  
-  public final static int ellipsoidarrows                = booleanparam | 62;  
-  public final static int ellipsoidaxes                  = booleanparam | 63;  
-  public final static int ellipsoidball                  = booleanparam | 64;  
-  public final static int ellipsoiddots                  = booleanparam | 65;  
-  public final static int ellipsoidfill                  = booleanparam | 66;  
-  public final static int filecaching                    = booleanparam | 67;
-  public final static int fontcaching                    = booleanparam | 68;
-  public final static int fontscaling                    = booleanparam | 69;
-  public final static int forceautobond                  = booleanparam | 71;
-  public final static int fractionalrelative             = booleanparam | 72;
+  public final static int elementkeys                     = booleanparam | 62;  
+  public final static int ellipsoidarcs                  = booleanparam | 63;  
+  public final static int ellipsoidarrows                = booleanparam | 64;  
+  public final static int ellipsoidaxes                  = booleanparam | 65;  
+  public final static int ellipsoidball                  = booleanparam | 66;  
+  public final static int ellipsoiddots                  = booleanparam | 67;  
+  public final static int ellipsoidfill                  = booleanparam | 68;  
+  public final static int filecaching                    = booleanparam | 69;
+  public final static int fontcaching                    = booleanparam | 70;
+  public final static int fontscaling                    = booleanparam | 71;
+  public final static int forceautobond                  = booleanparam | 72;
+  public final static int fractionalrelative             = booleanparam | 73;
 // see shapecommand public final static int frank                          = booleanparam | 72;
   public final static int greyscalerendering             = booleanparam | 74;
   public final static int hbondsbackbone                 = booleanparam | 76;
@@ -1501,7 +1502,7 @@ public class T {
   protected String toString2() {
     return "Token["
     + astrType[tok < keyword ? tok : keyword]
-    + "("+(tok%(1<<9))+"/0x" + Integer.toHexString(tok) + ")"
+    + "("+(tok%(1000))+"/0x" + Integer.toHexString(tok) + ")"
     + ((intValue == Integer.MAX_VALUE) ? "" : " intValue=" + intValue
         + "(0x" + Integer.toHexString(intValue) + ")")
     + ((value == null) ? "" : value instanceof String ? " value=\"" + value
@@ -2620,6 +2621,8 @@ public class T {
        "drawHover",
        "drawPicking",
        "dsspCalculateHydrogenAlways",
+       "elementKeys",
+       "elementKey",
        "ellipsoidArcs",
        "ellipsoidArrows",
        "ellipsoidAxes",
@@ -3697,6 +3700,8 @@ public class T {
         drawhover,                          //        "drawHover"
         drawpicking,                        //        "drawPicking"
         dsspcalchydrogen,                   //        "dsspCalculateHydrogenAlways"
+        elementkeys,
+        -1,
         ellipsoidarcs,                      //        "ellipsoidArcs"
         ellipsoidarrows,                    //        "ellipsoidArrows"
         ellipsoidaxes,                      //        "ellipsoidAxes"

--- a/src/org/jmol/scriptext/IsoExt.java
+++ b/src/org/jmol/scriptext/IsoExt.java
@@ -382,6 +382,14 @@ public class IsoExt extends ScriptExt {
             uc = vwr.getSymTemp()
                 .getUnitCell(eval.getPointArray(i + 1, -1, false), false, null);
             i = eval.iToken;
+          } else if (tokAt(i + 1) == T.string) {
+            // modelkit spacegroup xx unitcell "a,b,2c"
+            String tr = stringParameter(i + 1);
+            // empty string can be used here to skip this and add a title still
+            if (tr.length() > 0 && (uc = vwr.getCurrentUnitCell()) != null) {
+              uc = vwr.getSymTemp().getUnitCell(uc.getV0abc(tr, null), false, "draw");
+            }
+            i = eval.iToken;
           }
           if (tokAt(i + 1) == T.lattice) {
             if (tokIntersectBox == T.unitcell)
@@ -545,8 +553,8 @@ public class IsoExt extends ScriptExt {
           intScale = 0;
         } else {
           if (isAll && tokIntersectBox == T.unitcell) {
-            ((BZone) Interface.getInterface("org.jmol.util.BZone", vwr, "script"))
-            .drawHKL(vwr, thisId, plane, pts);
+            ((BZone) Interface.getInterface("org.jmol.util.BZone", vwr,
+                "script")).drawHKL(vwr, thisId, plane, pts);
 
           }
           propertyName = "polygon";
@@ -865,8 +873,8 @@ public class IsoExt extends ScriptExt {
           if (s == null)
             s = (String) vwr.getSymmetryInfo(iatom, xyz, iSym, trans, center,
                 target, T.draw, thisId, intScale / 100d, nth, options, opList);
-            s = "draw ID " + (isSymop ? "sg" : "sym")+ "* delete;" + s;
-            s = "draw ID " + thisId +"* delete;" + s + ";draw *;";
+          s = "draw ID " + (isSymop ? "sg" : "sym") + "* delete;" + s;
+          s = "draw ID " + thisId + "* delete;" + s + ";draw *;";
         }
         eval.runBufferedSafely(
             s.length() > 0 ? s : "draw ID \"" + thisId + "*\" delete",

--- a/src/org/jmol/shape/Balls.java
+++ b/src/org/jmol/shape/Balls.java
@@ -30,6 +30,7 @@ import org.jmol.c.PAL;
 import javajs.util.BS;
 import org.jmol.modelset.Atom;
 import org.jmol.util.C;
+import org.jmol.viewer.JC;
 
 public class Balls extends AtomShape {
 
@@ -77,7 +78,7 @@ public class Balls extends AtomShape {
             || pid != PAL.NONE.id);
         atom.paletteID = pid;
       }
-      vwr.setModelkitPropertySafely("key", bs);
+      vwr.setModelkitPropertySafely(JC.MODELKIT_UPDATE_ATOM_KEYS, bs);
       return;
     }
     if ("colorValues" == propertyName) {

--- a/src/org/jmol/shape/Echo.java
+++ b/src/org/jmol/shape/Echo.java
@@ -65,6 +65,69 @@ public class Echo extends TextShape {
   @Override
   public void setProperty(String propertyName, Object value, BS bs) {
 
+    if ("target" == propertyName) {
+      if ("%SCALE".equals(value)) {
+        currentObject = scaleObject;
+        thisID = "%SCALE";
+        if (currentObject != null)
+          return;
+      }
+      String target = ((String) value).intern().toLowerCase();
+      if (PT.isWild(target)) {
+        propertyName = "thisID";
+      } else if (target != "none" && target != "all") {
+        isAll = false;
+        Text text = (thisID == "%SCALE" ? scaleObject : objects.get(target));
+        if (text == null) {
+          int valign = JC.ECHO_XY;
+          int halign = JC.TEXT_ALIGN_LEFT;
+          if ("top" == target) {
+            valign = JC.ECHO_TOP;
+            halign = JC.TEXT_ALIGN_CENTER;
+          } else if ("middle" == target) {
+            valign = JC.ECHO_MIDDLE;
+            halign = JC.TEXT_ALIGN_CENTER;
+          } else if ("bottom" == target) {
+            valign = JC.ECHO_BOTTOM;
+          } else if ("error" == target) {
+            valign = JC.ECHO_TOP;
+          }
+          //          if (scaleObject != null && scaleObject.valign == valign
+          //              && scaleObject.align == halign) {
+          //            text = scaleObject;
+          //          } else {
+          text = Text.newEcho(vwr, vwr.gdata.getFont3DFS(FONTFACE, FONTSIZE),
+              target, COLOR, valign, halign, 0);
+          text.adjustForWindow = true;
+          if (thisID == "%SCALE") {
+            scaleObject = text;
+          } else {
+            objects.put(target, text);
+            if (target.startsWith(JC.THIS_MODEL_ONLY)) {
+              text.thisModelOnly = true;
+            }
+
+          }
+          if (currentFont != null)
+            text.setFont(currentFont, true);
+          if (currentColor != null)
+            text.colix = C.getColixO(currentColor);
+          if (currentBgColor != null)
+            text.bgcolix = C.getColixO(currentBgColor);
+          if (currentTranslucentLevel != 0)
+            text.setTranslucent(currentTranslucentLevel, false);
+          if (currentBgTranslucentLevel != 0)
+            text.setTranslucent(currentBgTranslucentLevel, true);
+          //          }
+        }
+        currentObject = text;
+        if (thisID != "%SCALE")
+          thisID = null;
+        return;
+      }
+    }
+
+
     if ("thisID" == propertyName) {
       if (value == null) {
         currentObject = null;
@@ -102,7 +165,7 @@ public class Echo extends TextShape {
     }
 
     if ("off" == propertyName) {
-      if (currentObject == scaleObject) {
+      if (currentObject != null && currentObject == scaleObject) {
         currentObject = scaleObject = null;
         return;
       }
@@ -122,66 +185,6 @@ public class Echo extends TextShape {
       }
       // continue to TextShape
     }
-    if ("target" == propertyName) {
-      if ("%SCALE".equals(value)) {
-        currentObject = scaleObject;
-        thisID = "%SCALE";
-        if (currentObject != null)
-          return;
-      }
-      String target = ((String) value).intern().toLowerCase();
-      if (target != "none" && target != "all") {
-        isAll = false;
-        Text text = (thisID == "%SCALE" ? scaleObject : objects.get(target));
-        if (text == null) {
-          int valign = JC.ECHO_XY;
-          int halign = JC.TEXT_ALIGN_LEFT;
-          if ("top" == target) {
-            valign = JC.ECHO_TOP;
-            halign = JC.TEXT_ALIGN_CENTER;
-          } else if ("middle" == target) {
-            valign = JC.ECHO_MIDDLE;
-            halign = JC.TEXT_ALIGN_CENTER;
-          } else if ("bottom" == target) {
-            valign = JC.ECHO_BOTTOM;
-          } else if ("error" == target) {
-            valign = JC.ECHO_TOP;
-          }
-          //          if (scaleObject != null && scaleObject.valign == valign
-          //              && scaleObject.align == halign) {
-          //            text = scaleObject;
-          //          } else {
-          text = Text.newEcho(vwr, vwr.gdata.getFont3DFS(FONTFACE, FONTSIZE),
-              target, COLOR, valign, halign, 0);
-          text.adjustForWindow = true;
-          if (thisID == "%SCALE") {
-            scaleObject = text;
-          } else {
-            objects.put(target, text);
-            if (target.startsWith(THIS_MODEL_ONLY)) {
-              text.thisModelOnly = true;
-            }
-
-          }
-          if (currentFont != null)
-            text.setFont(currentFont, true);
-          if (currentColor != null)
-            text.colix = C.getColixO(currentColor);
-          if (currentBgColor != null)
-            text.bgcolix = C.getColixO(currentBgColor);
-          if (currentTranslucentLevel != 0)
-            text.setTranslucent(currentTranslucentLevel, false);
-          if (currentBgTranslucentLevel != 0)
-            text.setTranslucent(currentBgTranslucentLevel, true);
-          //          }
-        }
-        currentObject = text;
-        if (thisID != "%SCALE")
-          thisID = null;
-        return;
-      }
-    }
-
     if ("scalereference" == propertyName) {
       if (currentObject != null) {
         double val = ((Number) value).doubleValue();

--- a/src/org/jmol/shape/Shape.java
+++ b/src/org/jmol/shape/Shape.java
@@ -88,13 +88,6 @@ import java.util.Map;
  */
 public abstract class Shape {
 
-  /**
-   * specifically for ECHO and DRAW to have these specific for a given model
-   * and only appearing when there is only one model showing (see MODELKIT SET KEY ON)
-   */
-  public static final String THIS_MODEL_ONLY = "_!_";
-  
-
   public String myType;
 
   abstract public String getShapeState();

--- a/src/org/jmol/shape/TextShape.java
+++ b/src/org/jmol/shape/TextShape.java
@@ -249,10 +249,12 @@ public abstract class TextShape extends Shape {
   @Override
   public void setModelVisibilityFlags(BS bsModels) {
     if (!isHover)
-      for (Text t : objects.values())
-        t.visible = (t.modelIndex < 0 || bsModels.get(t.modelIndex)
-            && (!t.thisModelOnly || bsModels.cardinality() == 1)
+      for (Text t : objects.values()) {
+        t.visible = (t.modelIndex < 0 
+            || bsModels.get(t.modelIndex)
+            && (!t.thisModelOnly || bsModels.cardinality() == 1 && t.modelIndex == vwr.am.cmi)
             );
+      }
   }
 
   @Override

--- a/src/org/jmol/shapespecial/Draw.java
+++ b/src/org/jmol/shapespecial/Draw.java
@@ -225,7 +225,7 @@ public class Draw extends MeshCollection {
         return;
       vData.addLast(new Object[] { Integer.valueOf(PT_MODEL_INDEX),
           (modelInfo = new int[] { indicatedModelIndex, 0 }) });
-      if (thisMesh.thisID.startsWith(THIS_MODEL_ONLY))
+      if (thisMesh.thisID.startsWith(JC.THIS_MODEL_ONLY))
         indicatedModelOnly = true;
       return;
     }
@@ -1248,7 +1248,6 @@ private void initDraw() {
         m.bsMeshesVisible.or(m.modelFlags);
         m.bsMeshesVisible.and(bsModels);
       }
-
     }
   }
   
@@ -1462,7 +1461,6 @@ private void initDraw() {
               continue;
             vTemp.normalize();
             vTemp.add(pickedPt);
-            //System.out.println("Draw " + vTemp + " " + pt + " " + pickedPt);
           }
           int d2 = coordinateInRange(x, y, (vnot >= 0 ? vTemp : pt), dmin2,
               ptXY);
@@ -1478,8 +1476,6 @@ private void initDraw() {
               pickedVertex = iVertex;
               pickedPt = pt;
               pickedMesh = m;
-//              System.out.println("pickedMesh, " + pickedMesh.hoverLabel
-//                  + " pm2 is " + (pm2 == null ? null : pm2.hoverLabel));
               pickedModel = iModel;
             }
             dmin2 = d2;

--- a/src/org/jmol/symmetry/SymmetryDesc.java
+++ b/src/org/jmol/symmetry/SymmetryDesc.java
@@ -1987,7 +1987,8 @@ public class SymmetryDesc {
           ((SymmetryOperation) sym.getSpaceGroupOperation(0)).timeReversal = 1;
         Object[][] infolist = new Object[ops.length][];
         String sops = "";
-        for (int i = 0, nop = 0; i < ops.length && nop != nth; i++) {
+        int i0 = (drawID == null || pt1 == null || pt2 == null && nth < 0 ? 0 : 1);
+        for (int i = i0, nop = 0; i < ops.length && nop != nth; i++) {
           SymmetryOperation op = ops[i];
           String xyzOriginal = op.xyzOriginal;
           int iop;

--- a/src/org/jmol/symmetry/SymmetryOperation.java
+++ b/src/org/jmol/symmetry/SymmetryOperation.java
@@ -231,7 +231,7 @@ public class SymmetryOperation extends M4d {
   boolean isBio;
   Matrix sigma;
   int number;
-  String subsystemCode;
+  public String subsystemCode;
   int timeReversal;
 
   private boolean unCentered;
@@ -242,7 +242,7 @@ public class SymmetryOperation extends M4d {
   private String opAxisCode;
   public boolean opIsLong;
 
-  void setSigma(String subsystemCode, Matrix sigma) {
+  public void setSigma(String subsystemCode, Matrix sigma) {
     this.subsystemCode = subsystemCode;
     this.sigma = sigma;
   }
@@ -589,7 +589,7 @@ public class SymmetryOperation extends M4d {
    * @param retString
    * @return canonized Jones-Faithful string
    */
-  static String getMatrixFromString(SymmetryOperation op, String xyz,
+  public static String getMatrixFromString(SymmetryOperation op, String xyz,
                                     double[] linearRotTrans,
                                     boolean allowScaling, boolean halfOrLess,
                                     boolean retString) {
@@ -1064,7 +1064,7 @@ public class SymmetryOperation extends M4d {
    * @param p
    * @return "1/2" for example
    */
-  static String fcoord(T3d p) {
+  public static String fcoord(T3d p) {
     // Castep reader only
     return fc(p.x) + " " + fc(p.y) + " " + fc(p.z);
   }
@@ -1090,7 +1090,7 @@ public class SymmetryOperation extends M4d {
     return PT.approxD(f, 1000000);
   }
 
-  static String getXYZFromRsVs(Matrix rs, Matrix vs, boolean is12ths) {
+  public static String getXYZFromRsVs(Matrix rs, Matrix vs, boolean is12ths) {
     double[][] ra = rs.getArray();
     double[][] va = vs.getArray();
     int d = ra.length;
@@ -1148,7 +1148,7 @@ public class SymmetryOperation extends M4d {
    * 
    * @param magRev
    */
-  void setTimeReversal(int magRev) {
+  public void setTimeReversal(int magRev) {
     timeReversal = magRev;
     if (xyz.indexOf("m") >= 0)
       xyz = xyz.substring(0, xyz.indexOf("m"));
@@ -1226,27 +1226,27 @@ public class SymmetryOperation extends M4d {
    * 
    * @param dim
    * @param m
-   * @param atoms
-   * @param atomIndex first index
-   * @param count number of atoms
+   * @param fracPts
+   * @param i0 first index
+   * @param n number of atoms
    */
-  public static void normalizeOperationToCentroid(int dim, M4d m, P3d[] atoms, int atomIndex, int count) {
-    if (count <= 0)
+  public static void normalizeOperationToCentroid(int dim, M4d m, P3d[] fracPts, int i0, int n) {
+    if (n <= 0)
       return;
     double x = 0;
     double y = 0;
     double z = 0;
     if (atomTest == null)
       atomTest = new P3d();
-    for (int i = atomIndex, i2 = i + count; i < i2; i++) {
-      Symmetry.newPoint(m, atoms[i], 0, 0, 0, atomTest);
+    for (int i = i0, i2 = i + n; i < i2; i++) {
+      m.rotTrans2(fracPts[i], atomTest);
       x += atomTest.x;
       y += atomTest.y;
       z += atomTest.z;
     }
-    x /= count;
-    y /= count;
-    z /= count;
+    x /= n;
+    y /= n;
+    z /= n;
     while (x < -0.001 || x >= 1.001) {
       m.m03 += (x < 0 ? 1 : -1);
       x += (x < 0 ? 1 : -1);
@@ -1964,6 +1964,12 @@ public class SymmetryOperation extends M4d {
       return 'g';
     }
     return (fx != 0 ? 'a' : fy != 0 ? 'b' : 'c');
+  }
+
+
+  static void rotateAndTranslatePoint(M4d m, P3d src, int ta, int tb, int tc, P3d dest) {
+    m.rotTrans2(src, dest);
+    dest.add3(ta, tb, tc);
   }
   
   // https://crystalsymmetry.wordpress.com/space-group-diagrams/

--- a/src/org/jmol/util/GData.java
+++ b/src/org/jmol/util/GData.java
@@ -37,6 +37,12 @@ public class GData implements JmolGraphicsInterface {
   protected boolean newAntialiasing;
 
   public int bgcolor;  
+ 
+  /**
+   *  WHITE or BLACK
+   */
+  public short contrastColix;
+  
   public int xLast, yLast;
   public int slab, depth;
   public int width, height;
@@ -170,6 +176,8 @@ public class GData implements JmolGraphicsInterface {
   }
 
   public int getColorArgbOrGray(short colix) {
+    if (colix == C.COLIX_CONTRAST)
+      return C.getArgb(contrastColix);
     if (colix < 0)
       colix = changeableColixMap[colix & C.UNMASK_CHANGEABLE_TRANSLUCENT];
     return (inGreyscaleMode ? C.getArgbGreyscale(colix) : C.getArgb(colix));

--- a/src/org/jmol/viewer/GlobalSettings.java
+++ b/src/org/jmol/viewer/GlobalSettings.java
@@ -256,6 +256,7 @@ public class GlobalSettings {
     setF("drawFontSize", drawFontSize);
     setB("drawPicking", drawPicking);
     setB("dsspCalculateHydrogenAlways", dsspCalcHydrogen);
+    setB("elementkeys", elementKeys);
 //    setO("edsUrlFormat", edsUrlFormat);
 //    setO("edsUrlFormatDiff", edsUrlFormatDiff);
 //    //setParameterValue("edsUrlOptions", edsUrlOptions);
@@ -630,6 +631,7 @@ public class GlobalSettings {
   boolean drawHover = false;
   boolean drawPicking = false;
   boolean dsspCalcHydrogen = true;
+  boolean elementKeys = false;
   public String energyUnits = "kJ";
   double exportScale = 0d;
   String helpPath = JC.DEFAULT_HELP_PATH;
@@ -1002,7 +1004,7 @@ public class GlobalSettings {
       + ";selecthetero;selecthydrogen"
       // removed in Jmol 14.32.68
       + ";pointgrouplineartolerance;pointgroupdistancetolerance"//;pointgroupmmaxatoms"
-      + ";minimizationreportsteps;symmetryhermannmauguin;")
+      + ";minimizationreportsteps;elementkeys;elementkey;symmetryhermannmauguin;")
       .toLowerCase();
 
   Object getAllVariables() {

--- a/src/org/jmol/viewer/JC.java
+++ b/src/org/jmol/viewer/JC.java
@@ -184,8 +184,6 @@ public final class JC {
       // still http:
       "aflowbin",
       "http://aflowlib.mems.duke.edu/users/jmolers/binary_new/%FILE.aflow_binary",
-      "aflow",
-      "http://aflowlib.mems.duke.edu/users/jmolers/binary_new/%FILE.aflow_binary",
       "aflowlib","https://www.aflowlib.org/prototype-encyclopedia/CIF/%FILE.cif",
       "aflowpro","$aflowlib",
       // _#DOCACHE_ flag indicates that the loaded file should be saved in any state in full
@@ -582,6 +580,10 @@ public final class JC {
   /* .cube files need this */
   public final static double ANGSTROMS_PER_BOHR = 0.5291772d;
 
+  
+  public static final int COLOR_CONTRAST = 0xFFfedcba;
+
+
   public final static int[] altArgbsCpk = { 0xFFFF1493, // Xx 0
       0xFFBFA6A6, // Al 13
       0xFFFFFF30, // S  16
@@ -594,6 +596,9 @@ public final class JC {
       0xFF105050, // 15N  7 - darker
   };
 
+  public final static int FORMAL_CHARGE_COLIX_RED = Elements.elementSymbols.length
+      + altArgbsCpk.length;
+  
   // hmmm ... what is shapely backbone? seems interesting
   //public final static int argbShapelyBackbone = 0xFFB8B8B8;
   //public final static int argbShapelySpecial =  0xFF5E005E;
@@ -612,6 +617,9 @@ public final class JC {
       0xFF2424FF, // 6
       0xFF0000FF, // 7
   };
+
+  public final static int PARTIAL_CHARGE_COLIX_RED = FORMAL_CHARGE_COLIX_RED
+      + argbsFormalCharge.length;
 
   public final static int[] argbsRwbScale = { 0xFFFF0000, // red
       0xFFFF1010, //
@@ -646,13 +654,9 @@ public final class JC {
       0xFF0000FF, // blue
   };
 
-  public final static int FORMAL_CHARGE_COLIX_RED = Elements.elementSymbols.length
-      + altArgbsCpk.length;
-  public final static int PARTIAL_CHARGE_COLIX_RED = FORMAL_CHARGE_COLIX_RED
-      + argbsFormalCharge.length;
   public final static int PARTIAL_CHARGE_RANGE_SIZE = argbsRwbScale.length;
 
-  //  $ print  color("red","blue", 33,true)
+//  $ print  color("red","blue", 33,true)
   //  [xff0000][xff2000][xff4000]
   //[xff6000][xff8000][xff9f00]
 
@@ -917,7 +921,8 @@ public final class JC {
 
       //periodic table
       "@nonmetal _H,_He,_B,_C,_N,_O,_F,_Ne,_Si,_P,_S,_Cl,_Ar,_As,_Se,_Br,_Kr,_Te,_I,_Xe,_At,_Rn",
-      "@metal !nonmetal && !_Xx", "@alkaliMetal _Li,_Na,_K,_Rb,_Cs,_Fr",
+      "@metal !nonmetal && !_Xx", 
+      "@alkaliMetal _Li,_Na,_K,_Rb,_Cs,_Fr",
       "@alkalineEarth _Be,_Mg,_Ca,_Sr,_Ba,_Ra",
       "@nobleGas _He,_Ne,_Ar,_Kr,_Xe,_Rn", "@metalloid _B,_Si,_Ge,_As,_Sb,_Te",
       // added La, Ac as per Frank Weinhold - these two are not f-block
@@ -931,6 +936,70 @@ public final class JC {
 
   };
 
+  /**
+   * specifically for ECHO and DRAW to have these specific for a given model
+   * and only appearing when there is only one model showing (see MODELKIT SET KEY ON)
+   */
+  public static final String THIS_MODEL_ONLY = "_!_";
+  public static final String MODELKIT_ELEMENT_KEY_ID = THIS_MODEL_ONLY + "elkey_";
+
+
+  public static final String MODELKIT_SET_ELEMENT_KEYS = "setelementkeys";
+  public static final String MODELKIT_KEY = "key";
+  public static final String MODELKIT_ELEMENT_KEY = "elementkey";
+  public static final String MODELKIT_ELEMENT_KEYS = "elementkeys";
+  public static final String MODELKIT_NEW_MODEL_ATOM_KEYS = "newmodelatomkeys";
+  public static final String MODELKIT_FRAME_RESIZED = "frameresized";
+  public static final String MODELKIT_UDPATE_KEY_STATE = "updatekeysfromstate";
+  public static final String MODELKIT_UPDATE_MODEL_KEYS = "updatemodelkeys";
+  public static final String MODELKIT_UPDATE_ATOM_KEYS = "updateatomkeys";
+  public static final String MODELKIT_ASSIGN_BOND = "assignBond";
+  public static final String MODELKIT_ROTATE_BOND_ATOM_INDEX = "rotateBond";
+  public static final String MODELKIT_BRANCH_ATOM_PICKED = "branchatomclicked";
+  public static final String MODELKIT_BRANCH_ATOM_DRAGGED = "branchatomdragged";
+  
+  public static final String MODELKIT_CENTER = "center";
+  public static final String MODELKIT_HIDEMENU = "hidemenu";
+  public static final String MODELKIT_CONSTRAINT = "constraint";
+  public static final String MODELKIT_EXISTS = "exists";
+  public static final String MODELKIT_ISMOLECULAR = "ismolecular";
+  public static final String MODELKIT_ALLOPERATORS = "alloperators";
+  public static final String MODELKIT_DATA = "data";
+  public static final String MODELKIT_MINIMIZING = "minimizing";
+  public static final String MODELKIT_RESET = "reset";
+  public static final String MODELKIT_ATOMPICKINGMODE = "atompickingmode";
+  public static final String MODELKIT_BONDPICKINGMODE = "bondpickingmode";
+  public static final String MODELKIT_HIGHLIGHT = "highlight";
+  public static final String MODELKIT_MODE = "mode";
+  public static final String MODELKIT_APPLYLOCAL = "applylocal";
+  public static final String MODELKIT_RETAINLOCAL = "retainlocal";
+  public static final String MODELKIT_APPLYFULL = "applyfull";
+  public static final String MODELKIT_UNITCELL = "unitcell";
+  public static final String MODELKIT_ADDHYDROGEN = "addhydrogen";
+  public static final String MODELKIT_ADDHYDROGENS = "addhydrogens";
+  public static final String MODELKIT_AUTOBOND = "autobond";
+  public static final String MODELKIT_CLICKTOSETELEMENT = "clicktosetelement";
+  public static final String MODELKIT_HIDDEN = "hidden";
+  public static final String MODELKIT_SHOWSYMOPINFO = "showsymopinfo";
+  public static final String MODELKIT_SYMOP = "symop";
+  public static final String MODELKIT_SYMMETRY = "symmetry";
+  public static final String MODELKIT_HOVERLABEL = "hoverlabel";
+  public static final String MODELKIT_ATOMTYPE = "atomtype";
+  public static final String MODELKIT_BONDTYPE = "bondtype";
+  public static final String MODELKIT_BONDINDEX = "bondindex";
+  public static final String MODELKIT_ROTATEBONDINDEX = "rotatebondindex";
+  public static final String MODELKIT_OFFSET = "offset";
+  public static final String MODELKIT_SCREENXY = "screenxy";
+  public static final String MODELKIT_INVARIANT = "invariant";
+  public static final String MODELKIT_DISTANCE = "distance";
+  public static final String MODELKIT_ADDCONSTRAINT = "addconstraint";
+  public static final String MODELKIT_REMOVECONSTRAINT = "removeconstraint";
+  public static final String MODELKIT_REMOVEALLCONSTRAINTS = "removeallconstraints";
+  public static final String MODELKIT_VIBRATION = "vibration";
+  public static final String MODELKIT_INITIALIZE_MODEL = "initializemodel";
+
+  public static final String MODELKIT_DRAGATOM = "dragatom";
+  public static final String MODELKIT_DELETE_BOND = "deletebond";
   public final static String MODELKIT_ZAP_STRING = "5\n\nC 0 0 0\nH .63 .63 .63\nH -.63 -.63 .63\nH -.63 .63 -.63\nH .63 -.63 -.63";
   public final static String MODELKIT_ZAP_TITLE = "Jmol Model Kit";//do not ever change this -- it is in the state
   public final static String ZAP_TITLE = "zapped";//do not ever change this -- it is in the state

--- a/src/org/jmol/viewer/Jmol.properties
+++ b/src/org/jmol/viewer/Jmol.properties
@@ -55,7 +55,281 @@ Jmol.___fullJmolProperties="src/org/jmol/viewer/Jmol.properties"
 # TODO: allow FIXED to work with MODELKIT MINIMIZE
 # TODO: brillouin zone issues with axes labels
 
-Jmol.___JmolVersion="16.1.64" // (swingJS) also 16.1.63 (legacy)
+Jmol.___JmolVersion="16.2.2" // (swingJS) also 16.2.1 (legacy)
+
+bug fix: when unit cells are modified, Symmetry should not be assumed to be unchanged.
+
+bug fix: unit cell information should only show space group if symmetry if the unit cell is appropriate
+
+bug fix: with set picking SYMMETRY, double-clicks should not start measurements
+
+bug fix: LOAD SUPERCELL should retain symmetry-relataed cell as "conventional"
+
+new feature: "contrast" color
+ -- for LABEL and ECHO, particularly
+ -- chooses WHITE or BLACK, depending upon the Jmol window background color
+ -- saved in the state as [xfedcba]
+ 
+new feature: set picking SYMMETRY now aliased with set picking SYMOP
+
+new feature: MODELKIT SPACEGROUP "HALL:xx xx xx" will create a space group from a Hall or extended Hall description
+ -- future enhancement will allow any HALL description
+ -- see  "Space-group notation with an explicit origin", S. R. Hall, Acta Cryst. (1981). A37, 517-525 https://doi.org/10.1107/S0567739481001228
+         http://macxray.chem.upenn.edu/LATT.pdf thank you, Patrick Carroll
+		 http://cci.lbl.gov/sginfo/hall_symbols.html
+		 http://cci.lbl.gov/cctbx/explore_symmetry.html
+ 
+new feature: MODELKIT SPACEGROUP ... UNITCELL [a b c alpha beta gamma] PACKED
+ -- after ZAP, creates a new space group with the given unit cell
+ -- optionally packing it, if not after ZAP
+ -- if the unit cell is incompatible with the space group, a similar compatible cell is used
+ 
+ 
+version: Version 16.2 represents a major advance in capability for Jmol, particularly in the 
+         area of space groups and symmetry in relation to 16.1.1, released 2023.01.24. 
+         The following is the listing of 90 new features since then, culled from this file and sorted. 
+         More detail on these can be found below.
+
+new feature: CONFIGURATION -n
+new feature: CONFIGURATION "A"
+new feature: "contrast" color
+new feature: crystal structure set picking dragMolecule with ALT implemented 
+new feature: DRAW "<hover>xxx</hover>...."
+new feature: DRAW boundbox $[isosurface id]
+new feature: DRAW boundbox BEST $[isosurface id]
+new feature: DRAW HOVERLABEL "xxx"
+new feature: DRAW SPACEGROUP @a n
+new feature: DRAW SPACEGROUP @n
+new feature: DRAW SPACEGROUP ALL 
+new feature: DRAW SYMOP [3,4,5] @1
+new feature: ECHO/DRAW with ID starting with "_!_" 
+new feature: Jmol application -A --scriptarguments flag
+new feature: LOAD "$?" load structure from NCI/CADD with prompt
+new feature: LOAD "*?" load PDB ID from EBI with prompt
+new feature: LOAD ":?" load structure from pubChem with prompt
+new feature: LOAD "=?" load PDB ID from RCSB with prompt
+new feature: LOAD "==?" load chemical component from RCSB with prompt
+new feature: LOAD .... fill "rhombohedral"
+new feature: LOAD .... fill "trigonal"
+new feature: LOAD =aflowlib/155.2
+new feature: LOAD...FILTER "lowPrecision" 
+new feature: LOAD...FILTER "PRECISION=n" where n is up to 16 digits
+new feature: LOAD - allow CIFReader to ignore COD 2107628 unmodulated operations in presence of modulated
+new feature: LOAD - AMS reader
+new feature: LOAD - BilbaoReader allows LOAD ... spacegroup ":n" to force origin, where n is 1 or 2
+new feature: LOAD - Binary CIF file structure reading. The BinaryCIF file format
+new feature: LOAD - CIFReader "ignoreGeomBond" (was SwingJS only)
+new feature: LOAD - CIFReader FILTER option NOWYCKOFF
+new feature: LOAD - CIFReader reads atom_site_wyckoff_label
+new feature: LOAD - CrystalMaker CMDF (binary) file reader
+new feature: LOAD - Jmol will accept CIF files with duplicate atom_site_label entries
+new feature: MACRO AFLOW adds SHOWSG(n,i,addSymmetry)
+new feature: MEASURE .... "default"
+new feature: MEASURE SELECT ALL
+new feature: MEASURE SELECT...
+new feature: MEASURE SELECTED
+new feature: MEASURE SELECTED ...
+new feature: MINIMIZE GROUP {atoms} 
+new feature: MINIMIZE ONLY {atoms} 
+new feature: MINIMIZE SELECT {atoms} 
+new feature: MODELKIT ADD <elem> WYCKOFF <Aa-z>
+new feature: MODELKIT MINIMIZE
+new feature: MODELKIT MOVETO @atoms @points
+new feature: MODELKIT SET KEY ON/OFF
+new feature: MODELKIT SPACEGROUP "HALL:xxxxx" will create a space group from a Hall or extended Hall description
+new feature: MODELKIT SPACEGROUP "x,y,z;x,-y,z;..."
+new feature: MODELKIT SPACEGROUP ... UNITCELL ...
+new feature: MODELKIT VIBRATION WYCKOFF; VIBRATION ON
+new feature: POLYHEDRA OFFSET {x, y, z} WIGNERSEITZ
+new feature: POLYHEDRA OFFSET 1.0 BRILLOUIN n   where n > 1
+new feature: POLYHEDRON LIST
+new feature: popup menu adds "atom picking..." Drag Atom and Drag Molecule
+new feature: RESTORE UNITCELL name
+new feature: SAVE UNITCELL name
+new feature: SELECT CONFIG=0
+new feature: SET minimizationReportSteps
+new feature: SET picking DRAGMOLECULE for crystal structures
+new feature: SET picking SYMMETRY now aliased with set picking SYMOP
+new feature: SET symmetryHM TRUE
+new feature: SMILES/ALLCOMPONENTS flag for generation of SMILES having multiple components
+new feature: threaded symmetry-aware UFF minimization of crystal structures.
+new feature: UFF minimization with application of symmetry for 
+new feature: UNITCELL [a,b,c,alpha,beta,gamma]
+new feature: UNITCELL RHOMBOHEDRAL and UNITCELL TRIGONAL (or HEXAGONAL - same)
+new feature: ZAP;MODELKIT SPACEGROUP ... UNITCELL [a b c alpha beta gamma] PACKED
+new feature: x = (array of SMILES strings).find("SMARTS" or "SMILES", pattern)
+new feature: x = _args() and _args(n)
+new feature: x = _arguments and _argumentCount added to SET CALLBACK "jmolscript:..."
+new feature: x = {*}.find("spacegroup", "parent") 
+new feature: x = {atomset}.atoms and {atomset}.label("%[atoms]")
+new feature: x = 3x3matrix%1
+new feature: x = 3x3matrix%2
+new feature: x = atomset.search(pat)
+new feature: x = compare(A, B, map) and compare(A, B, map, "stddev")
+new feature: x = function special variables _caller, _callers, _name
+new feature: x = pattern(<smarts string>) 
+new feature: x = search(target, pattern)
+new feature: x = spacegroup("ITA/155.1") 
+new feature: x = spacegroup("ITA/ALL") 
+new feature: x = symop("count")
+new feature: x = symop(matrix,option)
+new feature: x = symop("wyckoff")
+new feature: x = symop("wyckoff", "c")
+new feature: x = symop("wyckoff","C")
+new feature: x = symop("wyckoff","G")
+new feature: x = symop("wyckoff","S")
+new feature: x = @@3.symop("wyckoff",option)
+new feature: x = {atom}.wyckoff, label %[wyckoff], color PROPERTY WYCKOFF 
+new feature: x = string.pop()
+new feature: x = string.push("xx")
+
+This extends the initial set of 85 new crystallographic features introduced in version 15.2:
+   
+new feature: CALCULATE POINTGROUP {atoms}
+new feature: CALCULATE SPACEGROUP 
+new feature: CALCULATE SPACEGROUP {atoms}
+new feature: CENTER UNITCELL 
+new feature: DRAW HKL {1 1 1 x.x} 
+new feature: DRAW HKL {1 1 1} OFFSET x.x
+new feature: DRAW INTERCEPT UNITCELL xxx LATTICE {na nb nc}... HKL ....
+new feature: DRAW intersection [unitcell or boundbox description] [line or plane description]
+new feature: DRAW intersection [unitcell or boundbox description] LINE @1 @2 
+new feature: DRAW intersection [unitcell or boundbox description] ON [line or plane description]
+new feature: DRAW POINTGROUP {atoms} CENTER xx
+new feature: DRAW UNITCELL xxx LATTICE {na nb nc}
+new feature: GETPROPERTY unitCellInfo
+new feature: ISOSURFACE SLAB designations "a=" "b=" "c=" "-a=" "-b=" "-c=" "ab" "bc" "ac" "-ab" "-bc" "-ac"
+new feature: LOAD .... SPACEGROUP "Hall:P 2y"
+new feature: LOAD [some crystal structure] filter "POLYMERX"
+new feature: LOAD [some crystal structure] filter "SLABXY"
+new feature: LOAD spacegroup 213 unitcell [5 5 5 90 90 90]
+new feature: LOAD xxxx.mol FILTER "no3D" 
+new feature: LOAD xxxx.mol FILTER "noHydrogen" (Or just "NOH")
+new feature: MINIMIZE now works (minimally) with a crystal structure. 
+new feature: MODELKIT ON/OFF
+new feature: MODELKIT ADD "C" point [PACKED]
+new feature: MODELKIT ADD "Cl" {1/2 1/3 1/3}
+new feature: MODELKIT ADD "Cl" {1/2 1/3 1/3} PACKED
+new feature: MODELKIT ADD @1 
+new feature: MODELKIT ADD @1 "Cl" {1/2 1/3 1/3}
+new feature: MODELKIT ADD @1 "Cl" {1/2 1/3 1/3} PACKED
+new feature: MODELKIT ADD @1 "N"
+new feature: MODELKIT ADD @1 "N" PACKED
+new feature: MODELKIT ADD @1 PACKED
+new feature: MODELKIT ADD @2 "C" [PACKED]
+new feature: MODELKIT ADD @2 [PACKED]
+new feature: MODELKIT ADD {xxx} PACKED
+new feature: MODELKIT ADD C [array of points] 
+new feature: MODELKIT ADD/DELETE/MOVETO 
+new feature: MODELKIT CONNECT @1 @2 [0,1,2,3,4,5,p,m] (default 1)
+new feature: MODELKIT DELETE {atoms}
+new feature: MODELKIT FIXED NONE
+new feature: MODELKIT FIXED PLANE plane
+new feature: MODELKIT FIXED VECTOR point1 point2
+new feature: MODELKIT MOVETO @1 {1/2 0 0}
+new feature: MODELKIT MUTATE
+new feature: MODELKIT PACKED
+new feature: MODELKIT ROTATE axis1 axis2 {atoms} degrees
+new feature: MODELKIT SET autobond true
+new feature: MODELKIT SET hidden true
+new feature: MODELKIT SPACEGROUP
+new feature: MODELKIT SPACEGROUP "P1"
+new feature: MODELKIT SPACEGROUP 123
+new feature: MODELKIT SPACEGROUP 123 packed
+new feature: MODELKIT SPACEGROUP ... UNITCELL [a b c alpha beta gamma] PACKED
+new feature: MODELKIT SPACEGROUP "ITA/itno.setting" (e.g. "ITA/155.2")
+new feature: MODELKIT SPACEGROUP "HALL:xx xx xx" 
+new feature: MODELKIT UNDO/REDO
+new feature: MODELKIT UNITCELL [unitcell description]
+new feature: ModelKitCallback 
+new feature: MOVETO AXES [-][ab, bc, ca, ba, cb, ac][1, 2, 3, 4]
+new feature: plane designations "ab" "ab1" "ac "ac1" "bc" bc1" short for {0 0 1/1 0} {0 0 1/1 c} etc. 
+new feature: set picking dragAtom TRUE now recognizes symmetry for crystal structures
+new feature: UNITCELL FILL {na nb nc} 
+new feature: UNITCELL OFFSET @1; UNITCELL OFFSET {atoms}
+new feature: UNITCELL SUPERCELL {na nb nc} 
+new feature: UNITCELL SURFACE {h k l} [height | scale%] [offset or offset%] [TOP]
+new feature: x = @@1.symop(2, "invariant")
+new feature: x = @1.pointgroup("spacegroup")
+new feature: x = @1.symop("invariant")
+new feature: x = [{point},{point},...].find("equivalent", flags) {
+new feature: x = {*}.find("spacegroup") -- discovers the space group for a model 
+new feature: x = {*}.find("spacegroup","x,y,-z")
+new feature: x = {*}.inchi("fixedh?")
+new feature: x = {*}.inchi("standard")
+new feature: x = {1/2 1/2 1/2}.symop("invariant")
+new feature: x = {1/2 1/2 1/2}.symop(2, "invariant")
+new feature: x = {atoms}.pointGroup()
+new feature: x = hkl(1 0 0 0.3) to produce plane offset by 0.3 Angstroms from the origin.
+new feature: x = load(filename, asbinary, async) or load(filename, nbytesMax, async) or load(filename, "JSON", async)
+new feature: x = search(atomset)
+new feature: x = spacegroup("123") or spacegroup(123)
+new feature: x = spacegroup("x,y,z&-x,y,z") or spacegroup("&x,y,z;-x,y,z") or spacegroup("x,y,z;-x,y,z&")
+new feature: x = spacegroup("x,y,z;-x,y,z")
+new feature: x = spacegroup("x,y,z;-x,y,z", [a, b, c, alpha, beta, gamma])
+new feature: x = spacegroup(6, [a, b, c, alpha, beta, gamma])
+new feature: x = symop(2, "invariant")
+new feature: x = symop(3,@1,"array") adds "xyzNormalized"
+new feature: ZOOM UNITCELL 0
+new feature: ZOOMTO UNITCELL 0
+
+
+JmolVersion="16.1.66" // (swingJS) also 16.1.65 (legacy)
+
+bug fix: changing unit cell using just UNITCELL rather than MODELKIT UNITCELL improperly retains symmetry
+ -- when the unit cell is offset, symmetry should drop to P1
+ -- when the unit cell is RESET or otherwise returned to the one associated
+    with the space group, symmetry should be returned
+    
+bug fix: unit cell information displayed should represent the space group accurately
+ -- file-based symmetry initially should reflect the opertors from the file
+ -- after MODELKIT SPACEGROUP, the information should reflect a specific 
+    setting in Jmol and ITA, if found.
+
+new feature: MODELKIT SPACEGROUP ... UNITCELL ...
+ -- adds the ability to set the space group and unit cell at the same time
+ -- unit cell parameters must be compatible with the space group, or the action is aborted
+ -- unit cell can be expressed in one of three formats:
+    -- as the array [a b c alpha beta gamma] 
+    -- as the array  of cartesian vectors [origin, va, vb, vc}
+    -- as the setting transtormation string "a,b,c;0,0,0"  
+
+new feature: set symmetryHM TRUE
+ -- for show/calculate/draw POINTGROUP
+ -- TRUE switches to Hermann-Mauguin (2m, 2/m2/m2/m) notation
+ -- FALSE switches back to the default Schoenflies (C2v, D2h) notation 
+
+example script:
+
+ -- creating a group-subgroup comparison, where the transform between settings is known
+ -- based on information at https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-tranmax?way=up&super=20&sub=4&index=2&client=maxsub&what=&path=&series=&conj=all&type=t
+ 
+	zap
+	modelkit spacegroup 20
+	draw u20 unitcell color orange mesh nofill "uc-20"
+	modelkit add P Wyckoff G
+	// switching to sg 4 -- note that the listed transform matrix 
+	// is for subgroup to supergroup; we need the opposite here, thus the "!" prefix
+	modelkit spacegroup 4 unitcell "!1/2a+1/2b,c,1/2a-1/2b"
+	// drawing unit cell and operations
+	draw uc4 unitcell diameter 0.01 color orange mesh nofill "uc-4"
+	color property site
+	draw id "s12" symop @1 @2
+	draw id "s43" symop @4 @3
+	draw id "s56" symop @5 @6
+	draw id "s87" symop @8 @7
+	draw id "sg4" spacegroup all
+	//write c:\\temp\\iucr\\g20-sg4-w-4-draw.png as PNGJ
+	// switching back to sg 20:
+	modelkit spacegroup 20 unitcell "1/2a+1/2b,c,1/2a-1/2b"
+	print symop("wyckoff")
+	print {*}.wyckoff.pivot;
+	// switching to sg 4:   
+	modelkit spacegroup 4 unitcell "!1/2a+1/2b,c,1/2a-1/2b"
+	print symop("wyckoff")
+	print {*}.wyckoff.pivot;
+
+JmolVersion="16.1.64" // (swingJS) also 16.1.63 (legacy)
 
 bug fix: MODELKIT SET KEY ON  loses colored dot upon frame resizing
 

--- a/src/org/jmol/viewer/StateManager.java
+++ b/src/org/jmol/viewer/StateManager.java
@@ -275,7 +275,7 @@ public class StateManager {
   public boolean restoreUnitCell(String saveName) {
     String ucstate = getSavedUnitCell(saveName);
     if (ucstate == null) {
-      vwr.setModelCagePts(-1, null, null);
+      vwr.ms.setModelCagePts(-1, null, null);
       return false;
     }
     vwr.runScript(ucstate);

--- a/src/org/jmol/viewer/Viewer.java
+++ b/src/org/jmol/viewer/Viewer.java
@@ -792,7 +792,7 @@ public class Viewer extends JmolViewer
         isImageWrite || isReset ? g.zoomLarge : false, antialiased, false,
         false);
     gdata.setWindowParameters(width, height, antialiased);
-    setModelkitPropertySafely("modelkeys", BSUtil.newBitSet2(0, ms.mc));
+    setModelkitPropertySafely(JC.MODELKIT_FRAME_RESIZED, null);
     if (width > 0 && !isImageWrite)
       setStatusResized(width, height);
   }
@@ -3713,8 +3713,7 @@ public class Viewer extends JmolViewer
     }
     reset(true);
     selectAll();
-    if (modelkit != null)
-      modelkit.initializeForModel();
+    setModelkitPropertySafely(JC.MODELKIT_INITIALIZE_MODEL, null);
     movingSelected = false;
     slm.noneSelected = Boolean.FALSE;
     setHoverEnabled(true);
@@ -5341,7 +5340,7 @@ public class Viewer extends JmolViewer
       return;
     String label = (isLabel ? GT.$("Drag to move label")
         : isModelKitOpen() || isModelkitPickingActive() // force modelkit
-            ? (String) getModelkit(false).setProperty("hoverLabel",
+            ? (String) getModelkit(false).setProperty(JC.MODELKIT_HOVERLABEL,
                 Integer.valueOf(atomIndex))
             : null);
 
@@ -5477,7 +5476,7 @@ public class Viewer extends JmolViewer
     String name = ActionManager.getPickingModeName(acm.getAtomPickingMode());
     g.setO("picking", name);
     if (modelkit != null) {
-      modelkit.setProperty("atompickingmode", name);
+      modelkit.setProperty(JC.MODELKIT_ATOMPICKINGMODE, name);
       acm.setPickingMode(pickingMode);
       switch (pickingMode) {
       case ActionManager.PICKING_IDENTIFY:
@@ -5486,7 +5485,7 @@ public class Viewer extends JmolViewer
         break;
       case ActionManager.PICKING_DELETE_BOND:
       case ActionManager.PICKING_IDENTIFY_BOND:
-        modelkit.setProperty("bondpickingmode", strMode.toLowerCase());
+        modelkit.setProperty(JC.MODELKIT_BONDPICKINGMODE, strMode.toLowerCase());
         break;
       }
     }
@@ -5496,11 +5495,11 @@ public class Viewer extends JmolViewer
         + (option.length() == 1 ? "" : option.substring(1, 2));
     switch (pickingMode) {
     case ActionManager.PICKING_ASSIGN_ATOM:
-      getModelkit(false).setProperty("atomType", option);
+      getModelkit(false).setProperty(JC.MODELKIT_ATOMTYPE, option);
       break;
     case ActionManager.PICKING_ASSIGN_BOND:
       setBooleanPropertyTok("bondPicking", T.bondpicking, true);
-      getModelkit(false).setProperty("bondType", option);
+      getModelkit(false).setProperty(JC.MODELKIT_BONDTYPE, option);
       break;
     default:
       Logger.error("Bad picking mode: " + strMode + "_" + option);
@@ -6090,7 +6089,7 @@ public class Viewer extends JmolViewer
 
   boolean getBondsPickable() {
     return (g.bondPicking || isModelkitPickingActive() || isModelKitOpen()
-        && getModelkitPropertySafely("isMolecular") == Boolean.TRUE);
+        && getModelkitPropertySafely(JC.MODELKIT_ISMOLECULAR) == Boolean.TRUE);
   }
 
   boolean isModelKitOpen() {
@@ -6905,8 +6904,13 @@ public class Viewer extends JmolViewer
   public void setBooleanPropertyTok(String key, int tok, boolean value) {
     boolean doRepaint = true;
     switch (tok) {
+    case T.elementkeys:
+      // 16.2.1
+      g.elementKeys = value;
+      getModelkit(false).setProperty(JC.MODELKIT_SET_ELEMENT_KEYS, Boolean.valueOf(value));
+      break;
     case T.symmetryhermannmauguin:
-      // 16.1.66
+      // 16.1.65
       g.symmetryHermannMauguin = value;
       break;
     case T.doubleprecision:
@@ -7533,7 +7537,7 @@ public class Viewer extends JmolViewer
     g.setB("modelkitmode", value); // in case there is a callback before this completes
     highlight(null);
     if (isChange) {
-      setModelkitPropertySafely("constraint", null);
+      setModelkitPropertySafely(JC.MODELKIT_CONSTRAINT, null);
     }
     if (value) {
       setNavigationMode(false);
@@ -7561,7 +7565,7 @@ public class Viewer extends JmolViewer
       if (isChange) {
         sm.setStatusModelKit(0);
       } else if (!value) {
-        getModelkit(false).setProperty("hideMenu", null);
+        getModelkit(false).setProperty(JC.MODELKIT_HIDEMENU, null);
       }
     }
   }
@@ -8226,7 +8230,7 @@ public class Viewer extends JmolViewer
     ms.setAtomProperty(bs, tok, iValue, fValue, sValue, values, list);
     switch (tok) {
     case T.element:
-      setModelkitPropertySafely("key", bs);
+      setModelkitPropertySafely(JC.MODELKIT_UPDATE_ATOM_KEYS, bs);
       //$FALL-THROUGH$
     case T.atomx:
     case T.atomy:
@@ -8388,7 +8392,7 @@ public class Viewer extends JmolViewer
       return 0;
     if (ptNew == null) {
       if (x == Integer.MIN_VALUE && modelkit != null)
-        setModelkitPropertySafely("rotateBondIndex",
+        setModelkitPropertySafely(JC.MODELKIT_ROTATEBONDINDEX,
             Integer.valueOf(Integer.MIN_VALUE));
       if (deltaX == Integer.MIN_VALUE) {
         showSelected = true;
@@ -8412,7 +8416,7 @@ public class Viewer extends JmolViewer
     stopMinimization();
     // note this does not sync with applets
     if (ptNew == null && x != Integer.MIN_VALUE && modelkit != null
-        && modelkit.getProperty("rotateBondIndex") != null) {
+        && modelkit.getProperty(JC.MODELKIT_ROTATEBONDINDEX) != null) {
       modelkit.actionRotateBond(deltaX, deltaY, x, y,
           (modifiers & Event.VK_SHIFT) != 0);
     } else {
@@ -8485,9 +8489,9 @@ public class Viewer extends JmolViewer
     }
     highlight(bs);
     getModelkit(false);
-    setModelkitPropertySafely("screenXY", new int[] { x, y });
-    setModelkitPropertySafely("bondIndex", Integer.valueOf(index));
-    String text = (String) setModelkitPropertySafely("hoverLabel",
+    setModelkitPropertySafely(JC.MODELKIT_SCREENXY, new int[] { x, y });
+    setModelkitPropertySafely(JC.MODELKIT_BONDINDEX, Integer.valueOf(index));
+    String text = (String) setModelkitPropertySafely(JC.MODELKIT_HOVERLABEL,
         Integer.valueOf(-2 - index));
     if (text != null)
       hoverOnPt(x, y, text, null, null);
@@ -8507,7 +8511,7 @@ public class Viewer extends JmolViewer
       shm.loadShape(JC.SHAPE_HALOS);
       setCursor(GenericPlatform.CURSOR_HAND);
     }
-    setModelkitPropertySafely("highlight", bs);
+    setModelkitPropertySafely(JC.MODELKIT_HIGHLIGHT, bs);
     setShapeProperty(JC.SHAPE_HALOS, "highlight", bs);
   }
 
@@ -9389,7 +9393,7 @@ public class Viewer extends JmolViewer
 
     // only allow crystal symmetry constraints 
     if (isModelKitOpen())
-      setModelkitPropertySafely("constraint", null);
+      setModelkitPropertySafely(JC.MODELKIT_CONSTRAINT, null);
 
     if (bsInFrame == null)
       bsInFrame = getFrameAtoms();
@@ -10156,6 +10160,7 @@ public class Viewer extends JmolViewer
         bsB = (isQuick && vConnections.get(0).mi == ms.mc - 1
             ? ms.addHydrogens(vConnections, pts)
             : addHydrogensInline(bsAtoms, vConnections, pts, null));
+        setModelkitPropertySafely(JC.MODELKIT_UPDATE_ATOM_KEYS, bsAtoms);
       } catch (Exception e) {
         System.out.println(e.toString());
         // ignore
@@ -10897,7 +10902,7 @@ public class Viewer extends JmolViewer
    * @param asString
    * @param isAssign
    *        from ModelKit
-   * @param checkSupercell
+   * @param checkSupercell only true for x=spacegroup("parent")
    * @return either an array of space group identifiers or, if asString, "", or
    *         null
    * 
@@ -11097,8 +11102,8 @@ public class Viewer extends JmolViewer
     return se + u;
   }
 
-  public String assignSpaceGroup(BS bs, String type, double[] params) {
-    return getModelkit(false).cmdAssignSpaceGroup(bs, type, params);
+  public String assignSpaceGroup(BS bs, String type, Object paramsOrUC) {
+    return getModelkit(false).cmdAssignSpaceGroup(bs, type, paramsOrUC);
   }
 
   public void setStatusAtomMoved(boolean andCheckMinimize, BS bs) {
@@ -11140,20 +11145,6 @@ public class Viewer extends JmolViewer
       }
     }
     return false;
-  }
-
-  public void setModelCagePts(int iModel, T3d[] originABC, String name) {
-    if (iModel < 0)
-      iModel = am.cmi;
-    SymmetryInterface sym = Interface.getSymmetry(this, "cage");
-    if (sym == null && async)
-      throw new NullPointerException();
-    try {
-      ms.setModelCage(iModel,
-          originABC == null ? null : sym.getUnitCell(originABC, false, name));
-    } catch (Exception e) {
-      //
-    }
   }
 
 }


### PR DESCRIPTION
version: Version 16.2 represents a major advance in capability for Jmol, particularly in the 
         area of space groups and symmetry in relation to 16.1.1, released 2023.01.24. 
         The following is the listing of 90 new features since then, culled from this file and sorted. 
         More detail on these can be found below.

new feature: CONFIGURATION -n
new feature: CONFIGURATION "A"
new feature: "contrast" color
new feature: crystal structure set picking dragMolecule with ALT implemented 
new feature: DRAW "<hover>xxx</hover>...."
new feature: DRAW boundbox $[isosurface id]
new feature: DRAW boundbox BEST $[isosurface id]
new feature: DRAW HOVERLABEL "xxx"
new feature: DRAW SPACEGROUP @a n
new feature: DRAW SPACEGROUP @n
new feature: DRAW SPACEGROUP ALL 
new feature: DRAW SYMOP [3,4,5] @1
new feature: ECHO/DRAW with ID starting with "_!_" 
new feature: Jmol application -A --scriptarguments flag
new feature: LOAD "$?" load structure from NCI/CADD with prompt
new feature: LOAD "*?" load PDB ID from EBI with prompt
new feature: LOAD ":?" load structure from pubChem with prompt
new feature: LOAD "=?" load PDB ID from RCSB with prompt
new feature: LOAD "==?" load chemical component from RCSB with prompt
new feature: LOAD .... fill "rhombohedral"
new feature: LOAD .... fill "trigonal"
new feature: LOAD =aflowlib/155.2
new feature: LOAD...FILTER "lowPrecision" 
new feature: LOAD...FILTER "PRECISION=n" where n is up to 16 digits
new feature: LOAD - allow CIFReader to ignore COD 2107628 unmodulated operations in presence of modulated
new feature: LOAD - AMS reader
new feature: LOAD - BilbaoReader allows LOAD ... spacegroup ":n" to force origin, where n is 1 or 2
new feature: LOAD - Binary CIF file structure reading. The BinaryCIF file format
new feature: LOAD - CIFReader "ignoreGeomBond" (was SwingJS only)
new feature: LOAD - CIFReader FILTER option NOWYCKOFF
new feature: LOAD - CIFReader reads atom_site_wyckoff_label
new feature: LOAD - CrystalMaker CMDF (binary) file reader
new feature: LOAD - Jmol will accept CIF files with duplicate atom_site_label entries
new feature: MACRO AFLOW adds SHOWSG(n,i,addSymmetry)
new feature: MEASURE .... "default"
new feature: MEASURE SELECT ALL
new feature: MEASURE SELECT...
new feature: MEASURE SELECTED
new feature: MEASURE SELECTED ...
new feature: MINIMIZE GROUP {atoms} 
new feature: MINIMIZE ONLY {atoms} 
new feature: MINIMIZE SELECT {atoms} 
new feature: MODELKIT ADD <elem> WYCKOFF <Aa-z>
new feature: MODELKIT MINIMIZE
new feature: MODELKIT MOVETO @atoms @points
new feature: MODELKIT SET KEY ON/OFF
new feature: MODELKIT SPACEGROUP "HALL:xxxxx" will create a space group from a Hall or extended Hall description
new feature: MODELKIT SPACEGROUP "x,y,z;x,-y,z;..."
new feature: MODELKIT SPACEGROUP ... UNITCELL ...
new feature: MODELKIT VIBRATION WYCKOFF; VIBRATION ON
new feature: POLYHEDRA OFFSET {x, y, z} WIGNERSEITZ
new feature: POLYHEDRA OFFSET 1.0 BRILLOUIN n   where n > 1
new feature: POLYHEDRON LIST
new feature: popup menu adds "atom picking..." Drag Atom and Drag Molecule
new feature: RESTORE UNITCELL name
new feature: SAVE UNITCELL name
new feature: SELECT CONFIG=0
new feature: SET minimizationReportSteps
new feature: SET picking DRAGMOLECULE for crystal structures
new feature: SET picking SYMMETRY now aliased with set picking SYMOP
new feature: SET symmetryHM TRUE
new feature: SMILES/ALLCOMPONENTS flag for generation of SMILES having multiple components
new feature: threaded symmetry-aware UFF minimization of crystal structures.
new feature: UFF minimization with application of symmetry for 
new feature: UNITCELL [a,b,c,alpha,beta,gamma]
new feature: UNITCELL RHOMBOHEDRAL and UNITCELL TRIGONAL (or HEXAGONAL - same)
new feature: ZAP;MODELKIT SPACEGROUP ... UNITCELL [a b c alpha beta gamma] PACKED
new feature: x = (array of SMILES strings).find("SMARTS" or "SMILES", pattern)
new feature: x = _args() and _args(n)
new feature: x = _arguments and _argumentCount added to SET CALLBACK "jmolscript:..."
new feature: x = {*}.find("spacegroup", "parent") 
new feature: x = {atomset}.atoms and {atomset}.label("%[atoms]")
new feature: x = 3x3matrix%1
new feature: x = 3x3matrix%2
new feature: x = atomset.search(pat)
new feature: x = compare(A, B, map) and compare(A, B, map, "stddev")
new feature: x = function special variables _caller, _callers, _name
new feature: x = pattern(<smarts string>) 
new feature: x = search(target, pattern)
new feature: x = spacegroup("ITA/155.1") 
new feature: x = spacegroup("ITA/ALL") 
new feature: x = symop("count")
new feature: x = symop(matrix,option)
new feature: x = symop("wyckoff")
new feature: x = symop("wyckoff", "c")
new feature: x = symop("wyckoff","C")
new feature: x = symop("wyckoff","G")
new feature: x = symop("wyckoff","S")
new feature: x = @@3.symop("wyckoff",option)
new feature: x = {atom}.wyckoff, label %[wyckoff], color PROPERTY WYCKOFF 
new feature: x = string.pop()
new feature: x = string.push("xx")

This extends the initial set of 85 new crystallographic features introduced in version 15.2:
   
new feature: CALCULATE POINTGROUP {atoms}
new feature: CALCULATE SPACEGROUP 
new feature: CALCULATE SPACEGROUP {atoms}
new feature: CENTER UNITCELL 
new feature: DRAW HKL {1 1 1 x.x} 
new feature: DRAW HKL {1 1 1} OFFSET x.x
new feature: DRAW INTERCEPT UNITCELL xxx LATTICE {na nb nc}... HKL ....
new feature: DRAW intersection [unitcell or boundbox description] [line or plane description]
new feature: DRAW intersection [unitcell or boundbox description] LINE @1 @2 
new feature: DRAW intersection [unitcell or boundbox description] ON [line or plane description]
new feature: DRAW POINTGROUP {atoms} CENTER xx
new feature: DRAW UNITCELL xxx LATTICE {na nb nc}
new feature: GETPROPERTY unitCellInfo
new feature: ISOSURFACE SLAB designations "a=" "b=" "c=" "-a=" "-b=" "-c=" "ab" "bc" "ac" "-ab" "-bc" "-ac"
new feature: LOAD .... SPACEGROUP "Hall:P 2y"
new feature: LOAD [some crystal structure] filter "POLYMERX"
new feature: LOAD [some crystal structure] filter "SLABXY"
new feature: LOAD spacegroup 213 unitcell [5 5 5 90 90 90]
new feature: LOAD xxxx.mol FILTER "no3D" 
new feature: LOAD xxxx.mol FILTER "noHydrogen" (Or just "NOH")
new feature: MINIMIZE now works (minimally) with a crystal structure. 
new feature: MODELKIT ON/OFF
new feature: MODELKIT ADD "C" point [PACKED]
new feature: MODELKIT ADD "Cl" {1/2 1/3 1/3}
new feature: MODELKIT ADD "Cl" {1/2 1/3 1/3} PACKED
new feature: MODELKIT ADD @1 
new feature: MODELKIT ADD @1 "Cl" {1/2 1/3 1/3}
new feature: MODELKIT ADD @1 "Cl" {1/2 1/3 1/3} PACKED
new feature: MODELKIT ADD @1 "N"
new feature: MODELKIT ADD @1 "N" PACKED
new feature: MODELKIT ADD @1 PACKED
new feature: MODELKIT ADD @2 "C" [PACKED]
new feature: MODELKIT ADD @2 [PACKED]
new feature: MODELKIT ADD {xxx} PACKED
new feature: MODELKIT ADD C [array of points] 
new feature: MODELKIT ADD/DELETE/MOVETO 
new feature: MODELKIT CONNECT @1 @2 [0,1,2,3,4,5,p,m] (default 1)
new feature: MODELKIT DELETE {atoms}
new feature: MODELKIT FIXED NONE
new feature: MODELKIT FIXED PLANE plane
new feature: MODELKIT FIXED VECTOR point1 point2
new feature: MODELKIT MOVETO @1 {1/2 0 0}
new feature: MODELKIT MUTATE
new feature: MODELKIT PACKED
new feature: MODELKIT ROTATE axis1 axis2 {atoms} degrees
new feature: MODELKIT SET autobond true
new feature: MODELKIT SET hidden true
new feature: MODELKIT SPACEGROUP
new feature: MODELKIT SPACEGROUP "P1"
new feature: MODELKIT SPACEGROUP 123
new feature: MODELKIT SPACEGROUP 123 packed
new feature: MODELKIT SPACEGROUP ... UNITCELL [a b c alpha beta gamma] PACKED
new feature: MODELKIT SPACEGROUP "ITA/itno.setting" (e.g. "ITA/155.2")
new feature: MODELKIT SPACEGROUP "HALL:xx xx xx" 
new feature: MODELKIT UNDO/REDO
new feature: MODELKIT UNITCELL [unitcell description]
new feature: ModelKitCallback 
new feature: MOVETO AXES [-][ab, bc, ca, ba, cb, ac][1, 2, 3, 4]
new feature: plane designations "ab" "ab1" "ac "ac1" "bc" bc1" short for {0 0 1/1 0} {0 0 1/1 c} etc. 
new feature: set picking dragAtom TRUE now recognizes symmetry for crystal structures
new feature: UNITCELL FILL {na nb nc} 
new feature: UNITCELL OFFSET @1; UNITCELL OFFSET {atoms}
new feature: UNITCELL SUPERCELL {na nb nc} 
new feature: UNITCELL SURFACE {h k l} [height | scale%] [offset or offset%] [TOP]
new feature: x = @@1.symop(2, "invariant")
new feature: x = @1.pointgroup("spacegroup")
new feature: x = @1.symop("invariant")
new feature: x = [{point},{point},...].find("equivalent", flags) {
new feature: x = {*}.find("spacegroup") -- discovers the space group for a model 
new feature: x = {*}.find("spacegroup","x,y,-z")
new feature: x = {*}.inchi("fixedh?")
new feature: x = {*}.inchi("standard")
new feature: x = {1/2 1/2 1/2}.symop("invariant")
new feature: x = {1/2 1/2 1/2}.symop(2, "invariant")
new feature: x = {atoms}.pointGroup()
new feature: x = hkl(1 0 0 0.3) to produce plane offset by 0.3 Angstroms from the origin.
new feature: x = load(filename, asbinary, async) or load(filename, nbytesMax, async) or load(filename, "JSON", async)
new feature: x = search(atomset)
new feature: x = spacegroup("123") or spacegroup(123)
new feature: x = spacegroup("x,y,z&-x,y,z") or spacegroup("&x,y,z;-x,y,z") or spacegroup("x,y,z;-x,y,z&")
new feature: x = spacegroup("x,y,z;-x,y,z")
new feature: x = spacegroup("x,y,z;-x,y,z", [a, b, c, alpha, beta, gamma])
new feature: x = spacegroup(6, [a, b, c, alpha, beta, gamma])
new feature: x = symop(2, "invariant")
new feature: x = symop(3,@1,"array") adds "xyzNormalized"
new feature: ZOOM UNITCELL 0
new feature: ZOOMTO UNITCELL 0


JmolVersion="16.1.66" // (swingJS) also 16.1.65 (legacy)

bug fix: changing unit cell using just UNITCELL rather than MODELKIT UNITCELL improperly retains symmetry
 -- when the unit cell is offset, symmetry should drop to P1
 -- when the unit cell is RESET or otherwise returned to the one associated
    with the space group, symmetry should be returned
    
bug fix: unit cell information displayed should represent the space group accurately
 -- file-based symmetry initially should reflect the opertors from the file
 -- after MODELKIT SPACEGROUP, the information should reflect a specific 
    setting in Jmol and ITA, if found.

new feature: MODELKIT SPACEGROUP ... UNITCELL ...
 -- adds the ability to set the space group and unit cell at the same time
 -- unit cell parameters must be compatible with the space group, or the action is aborted
 -- unit cell can be expressed in one of three formats:
    -- as the array [a b c alpha beta gamma] 
    -- as the array  of cartesian vectors [origin, va, vb, vc}
    -- as the setting transtormation string "a,b,c;0,0,0"  

new feature: set symmetryHM TRUE
 -- for show/calculate/draw POINTGROUP
 -- TRUE switches to Hermann-Mauguin (2m, 2/m2/m2/m) notation
 -- FALSE switches back to the default Schoenflies (C2v, D2h) notation 

example script:

 -- creating a group-subgroup comparison, where the transform between settings is known
 -- based on information at https://www.cryst.ehu.es/cgi-bin/cryst/programs/nph-tranmax?way=up&super=20&sub=4&index=2&client=maxsub&what=&path=&series=&conj=all&type=t
 
	zap
	modelkit spacegroup 20
	draw u20 unitcell color orange mesh nofill "uc-20"
	modelkit add P Wyckoff G
	// switching to sg 4 -- note that the listed transform matrix 
	// is for subgroup to supergroup; we need the opposite here, thus the "!" prefix
	modelkit spacegroup 4 unitcell "!1/2a+1/2b,c,1/2a-1/2b"
	// drawing unit cell and operations
	draw uc4 unitcell diameter 0.01 color orange mesh nofill "uc-4"
	color property site
	draw id "s12" symop @1 @2
	draw id "s43" symop @4 @3
	draw id "s56" symop @5 @6
	draw id "s87" symop @8 @7
	draw id "sg4" spacegroup all
	//write c:\\temp\\iucr\\g20-sg4-w-4-draw.png as PNGJ
	// switching back to sg 20:
	modelkit spacegroup 20 unitcell "1/2a+1/2b,c,1/2a-1/2b"
	print symop("wyckoff")
	print {*}.wyckoff.pivot;
	// switching to sg 4:   
	modelkit spacegroup 4 unitcell "!1/2a+1/2b,c,1/2a-1/2b"
	print symop("wyckoff")
	print {*}.wyckoff.pivot;
