### PR TITLE
Add protocol part to the "www.opensource.org" URL

### DIFF
--- a/src/org/openscience/jmol/app/jmolpanel/About.html
+++ b/src/org/openscience/jmol/app/jmolpanel/About.html
@@ -8,7 +8,7 @@
   <center>About.html#splash</center>
 
 
-  <p><b>Jmol is an <a href="www.opensource.org">Open Source</a> molecular viewer 
+  <p><b>Jmol is an <a href="https://www.opensource.org">Open Source</a> molecular viewer
   licensed under the <a href="https://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>.</b></p>
     
   About.html#version About.html#weblinks

--- a/src/org/openscience/jmol/app/jmolpanel/About_es.html
+++ b/src/org/openscience/jmol/app/jmolpanel/About_es.html
@@ -7,7 +7,7 @@
   <body bgcolor="#ffffff">
   <center>About.html#splash</center>
 
-  <p><b>Jmol es un programa de <a href="www.opensource.org">código abierto</a> para visualizar moléculas,
+  <p><b>Jmol es un programa de <a href="https://www.opensource.org">código abierto</a> para visualizar moléculas,
   con licencia de uso <a href="https://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>.</b></p>
 
   About.html#version About.html#weblinks


### PR DESCRIPTION
Without an explicit protocol part (e.g. "https://") the link fails to open when clicked in the "Help" -> "About Jmol" panel.